### PR TITLE
RENO-1606 Fix Deployment Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,10 @@ install: npm install
 
 before_script:
   - cp .travis/.env .
-  - "./provisioning/set-env"
+  - ./provisioning/set-env
 
 script: npm test
 
-before_deploy: echo 'All tests passed; Preparing to deploy'
-
-deploy:
-  provider: script
-  script: provisioning/deploy
-  on:
-    all_branches: true
+after_success:
+  - echo 'All tests passed; Preparing to deploy'
+  - ./provisioning/deploy

--- a/provisioning/deploy
+++ b/provisioning/deploy
@@ -1,44 +1,47 @@
 #! /bin/bash
 
-case "$TRAVIS_BRANCH" in
-  production)
-    export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID_PRODUCTION
-    export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY_PRODUCTION
-    DOCKER_REPO_URL=$REMOTE_IMAGE_URL_NYPL
-    ;;
-  *)
-    export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID_DEVELOPMENT
-    export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY_DEVELOPMENT
-    DOCKER_REPO_URL=$REMOTE_IMAGE_URL_NYPL_DEV
-    ;;
-esac
+# Deploy only if it's not a pull request
+if [ -z "$TRAVIS_PULL_REQUEST" ] || [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+  case "$TRAVIS_BRANCH" in
+    production)
+      export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID_PRODUCTION
+      export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY_PRODUCTION
+      DOCKER_REPO_URL=$REMOTE_IMAGE_URL_NYPL
+      ;;
+    *)
+      export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID_DEVELOPMENT
+      export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY_DEVELOPMENT
+      DOCKER_REPO_URL=$REMOTE_IMAGE_URL_NYPL_DEV
+      ;;
+  esac
 
-# This is needed to login on AWS and push the image on ECR
-# Change it accordingly to your docker repo
-pip install --user awscli
-export PATH=$PATH:$HOME/.local/bin
-eval $(aws ecr get-login --no-include-email --region us-east-1)
+  # This is needed to login on AWS and push the image on ECR
+  # Change it accordingly to your docker repo
+  pip install --user awscli
+  export PATH=$PATH:$HOME/.local/bin
+  eval $(aws ecr get-login --no-include-email --region us-east-1)
 
-# awscli v2 client uses new login routine
-# aws ecr get-login-password --region us-east-1 --profile nypl-dev \
-# | docker login \
-#     --password-stdin \
-#     --username AWS \
-#     $DOCKER_REPO_URL
+  # awscli v2 client uses new login routine
+  # aws ecr get-login-password --region us-east-1 --profile nypl-dev \
+  # | docker login \
+  #     --password-stdin \
+  #     --username AWS \
+  #     $DOCKER_REPO_URL
 
-# Build and push to ECR.
-IMAGE_NAME=nypldxpsearch
-LOCAL_TAG_NAME=$IMAGE_NAME:$TRAVIS_BRANCH-latest
-REMOTE_FULL_URL=$DOCKER_REPO_URL:$TRAVIS_BRANCH-latest
-docker build --target production --tag $LOCAL_TAG_NAME .
-echo "Pushing $LOCAL_TAG_NAME"
-docker tag $LOCAL_TAG_NAME "$REMOTE_FULL_URL"
-docker push "$REMOTE_FULL_URL"
-echo "Pushed $LOCAL_TAG_NAME to $REMOTE_FULL_URL"
+  # Build and push to ECR.
+  IMAGE_NAME=nypldxpsearch
+  LOCAL_TAG_NAME=$IMAGE_NAME:$TRAVIS_BRANCH-latest
+  REMOTE_FULL_URL=$DOCKER_REPO_URL:$TRAVIS_BRANCH-latest
+  docker build --target production --tag $LOCAL_TAG_NAME .
+  echo "Pushing $LOCAL_TAG_NAME"
+  docker tag $LOCAL_TAG_NAME "$REMOTE_FULL_URL"
+  docker push "$REMOTE_FULL_URL"
+  echo "Pushed $LOCAL_TAG_NAME to $REMOTE_FULL_URL"
 
-# Restart ECS services.
-CLUSTER_NAME="nyplorg-scout-$TRAVIS_BRANCH"
-WEB_APP_SERVICE_NAME="nyplorg-scout-$TRAVIS_BRANCH"
+  # Restart ECS services.
+  CLUSTER_NAME="nyplorg-scout-$TRAVIS_BRANCH"
+  WEB_APP_SERVICE_NAME="nyplorg-scout-$TRAVIS_BRANCH"
 
-echo "Deploying $TRAVIS_BRANCH"
-AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION aws ecs update-service --cluster $CLUSTER_NAME --region us-east-1 --service $WEB_APP_SERVICE_NAME --force-new-deployment
+  echo "Deploying $TRAVIS_BRANCH"
+  AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION aws ecs update-service --cluster $CLUSTER_NAME --region us-east-1 --service $WEB_APP_SERVICE_NAME --force-new-deployment
+fi


### PR DESCRIPTION
[Jira Ticket](http://jira.nypl.org/browse/RENO-1606)

**This PR does the following:**
- Changes TravisCI deployment to use the `after_success` directive instead of `deploy` which may be interfering with build files. This puts it on par with how nypl-d8 is deployed via TravisCI.

May not be able to test until deployed via the `qa` branch.