### PR TITLE
RENO-1657: Setup GA Tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ NEXT_PUBLIC_GRAPHQL_API=http://localhost:3000/api/graphql
 D8_JSON_API=http://localhost:8080/jsonapi
 REFINERY_API=https://refinery.nypl.org/api/nypl
 NEXT_PUBLIC_GOOGLE_MAPS_API=x1234x
+NEXT_PUBLIC_GA_TRACKING_ID=UA-x1234x

--- a/provisioning/set-env
+++ b/provisioning/set-env
@@ -1,10 +1,14 @@
 #! /bin/bash
 
+# Set production values
 GRAPHQL_API_URL=https://scout.nypl.org/api/graphql
+GA_TRACKING_ID=UA-1420324-3
 
 if [ "$TRAVIS_BRANCH" == "qa" ]; then
   GRAPHQL_API_URL=https://qa-scout.nypl.org/api/graphql
+  GA_TRACKING_ID=UA-1420324-122
 fi
 
 echo -e "\nNEXT_PUBLIC_GRAPHQL_API=$GRAPHQL_API_URL" >> .env
 echo -e "\nNEXT_PUBLIC_GOOGLE_MAPS_API=$NEXT_PUBLIC_GOOGLE_MAPS_API" >> .env
+echo -e "\nNEXT_PUBLIC_GA_TRACKING_ID=$GA_TRACKING_ID" >> .env

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -1,10 +1,29 @@
+const { NEXT_PUBLIC_GA_TRACKING_ID } = process.env;
 import Document, { Html, Head, Main, NextScript } from 'next/document';
 
 class ScoutDocument extends Document {
   render() {
     return (
       <Html lang="en">
-        <Head />
+        <Head>
+          {/* Global Site Tag (gtag.js) - Google Analytics */}
+          <script
+            async
+            src={`https://www.googletagmanager.com/gtag/js?id=${NEXT_PUBLIC_GA_TRACKING_ID}`}
+          />
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', '${NEXT_PUBLIC_GA_TRACKING_ID}', {
+                  page_path: window.location.pathname,
+                });
+              `,
+            }}
+          />
+        </Head>
         <body>
           <Main />
           <NextScript />

--- a/src/utils/analytics.js
+++ b/src/utils/analytics.js
@@ -1,9 +1,0 @@
-// @TODO Might not need this file?
-const { NEXT_PUBLIC_GA_TRACKING_ID } = process.env;
-
-// https://developers.google.com/analytics/devguides/collection/gtagjs/pages
-export const pageview = (url) => {
-  window.gtag('config', NEXT_PUBLIC_GA_TRACKING_ID, {
-    page_path: url,
-  })
-}

--- a/src/utils/analytics.js
+++ b/src/utils/analytics.js
@@ -1,0 +1,9 @@
+// @TODO Might not need this file?
+const { NEXT_PUBLIC_GA_TRACKING_ID } = process.env;
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/pages
+export const pageview = (url) => {
+  window.gtag('config', NEXT_PUBLIC_GA_TRACKING_ID, {
+    page_path: url,
+  })
+}


### PR DESCRIPTION
[Jira Ticket](http://jira.nypl.org/browse/RENO-1657)

**This PR does the following:**
- Adds .env.example variable for NEXT_PUBLIC_GA_TRACKING_ID
- Wires up _document.js in Next to render the GA tracking script
- Rough draft of adding the .env variables for GA Tracking ID on QA and PROD to `provisioning/set-env`

### Review Steps:
- [x] Pull in latest code
- [x] npm install
- [x] Update local .env file w/ new var `NEXT_PUBLIC_GA_TRACKING_ID=UA-1420324-122`
- [x] npm run dev
- [x] Goto local app: http://localhost:3000/location-finder
- [x] Confirm GA is connected properly: GA > Realtime > Overview and you should see an entry for `/location-finder` with your location.
- [x] Update `provisioning/set-env` as needed to work properly on AWS.

### Front End Review Steps:
- [ ] View [Example](http://localhost:3000/location-finder)
