### PR TITLE
RENO-1677: Open Now Filter Shows Locations That Are Closed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5641,6 +5641,16 @@
         }
       }
     },
+    "date-fns": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.16.0.tgz",
+      "integrity": "sha512-DWTRyfOA85sZ4IiXPHhiRIOs3fW5U6Msrp+gElXARa6EpoQTXPyHQmh7hr+ssw2nx9FtOQWnAMJKgL5vaJqILw=="
+    },
+    "date-fns-tz": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.0.10.tgz",
+      "integrity": "sha512-cHQAz0/9uDABaUNDM80Mj1FL4ODlxs1xEY4b0DQuAooO2UdNKvDkNbV8ogLnxLbv02Ru1HXFcot0pVvDRBgptg=="
+    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "apollo-server-micro": "^2.16.1",
     "apollo-utilities": "^1.3.2",
     "breakpoint-sass": "2.7.0",
+    "date-fns": "^2.16.0",
+    "date-fns-tz": "^1.0.10",
     "graphql": "^14.7.0",
     "graphql-tag": "2.10.3",
     "next": "latest",

--- a/src/apollo/server/datasources/RefineryApi.js
+++ b/src/apollo/server/datasources/RefineryApi.js
@@ -39,6 +39,18 @@ class RefineryApi extends RESTDataSource {
       }
     });
 
+    // Open status
+    let open = false;
+    if (
+      // Extended closing
+      location.open
+      // Alert closing
+      && location._embedded.alerts === undefined
+      || location._embedded.alerts.length === 0
+    ) {
+      open = true;
+    }
+
     return {
       id: location.slug,
       name: location.name,
@@ -59,7 +71,7 @@ class RefineryApi extends RESTDataSource {
         start: todayHoursStart,
         end: todayHoursEnd
       },
-      open: location.open,
+      open: open,
     }
   }
 

--- a/src/apollo/server/datasources/RefineryApi.js
+++ b/src/apollo/server/datasources/RefineryApi.js
@@ -2,6 +2,7 @@ import { RESTDataSource } from 'apollo-datasource-rest';
 const { REFINERY_API } = process.env;
 import sortByDistance from './../../../utils/sortByDistance';
 import filterByOpenNow from './../../../utils/filterByOpenNow';
+import checkAlertsOpenStatus from './../../../utils/checkAlertsOpenStatus';
 import sortByName from './../../../utils/sortByName';
 
 class RefineryApi extends RESTDataSource {
@@ -40,25 +41,7 @@ class RefineryApi extends RESTDataSource {
     });
 
     // Alerts
-    const alerts = location._embedded.alerts;
-    let alertsOpenStatus;
-    // Check for any alerts.
-    if (alerts === undefined || alerts.length === 0) {
-      // No alerts, so set this status to true.
-      // Other checks below will determine if the location is open.
-      alertsOpenStatus = true;
-    } else {
-      // We have alerts, so map over them.
-      alerts.map(alert => {
-        // Check if closed_for key exists
-        // If so, set the status to false.
-        if ('closed_for' in alert) {
-          alertsOpenStatus = false;
-        } else {
-          alertsOpenStatus = true;
-        }
-      });
-    }
+    const alertsOpenStatus = checkAlertsOpenStatus(location);
 
     // Open status
     let open = false;

--- a/src/apollo/server/datasources/RefineryApi.js
+++ b/src/apollo/server/datasources/RefineryApi.js
@@ -39,14 +39,34 @@ class RefineryApi extends RESTDataSource {
       }
     });
 
+    // Alerts
+    const alerts = location._embedded.alerts;
+    let alertsOpenStatus;
+    // Check for any alerts.
+    if (alerts === undefined || alerts.length === 0) {
+      // No alerts, so set this status to true.
+      // Other checks below will determine if the location is open.
+      alertsOpenStatus = true;
+    } else {
+      // We have alerts, so map over them.
+      alerts.map(alert => {
+        // Check if closed_for key exists
+        // If so, set the status to false.
+        if ('closed_for' in alert) {
+          alertsOpenStatus = false;
+        } else {
+          alertsOpenStatus = true;
+        }
+      });
+    }
+
     // Open status
     let open = false;
     if (
       // Extended closing
       location.open
       // Alert closing
-      && location._embedded.alerts === undefined
-      || location._embedded.alerts.length === 0
+      && alertsOpenStatus
     ) {
       open = true;
     }
@@ -87,7 +107,7 @@ class RefineryApi extends RESTDataSource {
   }
 
   async getAllLocations(args) {
-    const response = await this.get('/locations/v1.0/locations?page[size]=300');
+    const response = await this.get('/locations/v1.0/locations');
 
     if (Array.isArray(response.locations)) {
       let results;

--- a/src/components/location-finder/Locations/Locations.js
+++ b/src/components/location-finder/Locations/Locations.js
@@ -82,7 +82,7 @@ function Locations() {
   }
 
   // No results.
-  if (data.allLocations.length === 0) {
+  if (data.allLocations.locations.length === 0) {
     return (
       <div className='no-results'>Try adjusting search terms or filters.</div>
     );

--- a/src/utils/checkAlertsOpenStatus.js
+++ b/src/utils/checkAlertsOpenStatus.js
@@ -1,0 +1,58 @@
+const { zonedTimeToUtc, utcToZonedTime, format } = require('date-fns-tz');
+var parseISO = require('date-fns/parseISO');
+
+function checkAlertsOpenStatus(location) {
+  const alerts = location._embedded.alerts;
+  const tz = 'America/New_York';
+
+  let alertsOpenStatus;
+  // Check for any alerts.
+  if (alerts === undefined || alerts.length === 0) {
+    // No alerts, so set this status to true.
+    // Other checks below will determine if the location is open.
+    alertsOpenStatus = true;
+  } else {
+    // We have alerts, so map over them.
+    alerts.map(alert => {
+      // Check if closed_for key exists
+      if ('closed_for' in alert) {
+        // Compare alert.applies.start + alert.applies.end to today.
+        //
+        // Refinery Format:
+        // 2020-07-08T00:00:00-04:00 -- 2030-07-09T00:00:00-04:00
+        //
+        // @SEE https://github.com/NYPL/locations-app/search?q=applies.start&unscoped_q=applies.start
+        //
+        if (alert.applies.start && alert.applies.end) {
+          // Get today date only
+          const utcToday = utcToZonedTime(new Date(), tz);
+          const today = format(utcToday, 'yyyy-MM-dd', { timeZone: tz });
+          console.log('today: ' + today);
+
+          // Get start day
+          // We strip off incorrect offset added.
+          const startDay = format(parseISO(alert.applies.start.replace('-04:00', '')), 'yyyy-MM-dd', { timeZone: tz });
+          console.log('startDay: ' + startDay);
+
+          // Get end day
+          // We strip off incorrect offset added.
+          const endDay = format(parseISO(alert.applies.end.replace('-04:00', '')), 'yyyy-MM-dd', { timeZone: tz });
+          console.log('endDay: ' + endDay);
+
+          // Compare startDay, endDay against today
+          if (today != startDay && today <= endDay) {
+            alertsOpenStatus = false;
+          } else {
+            alertsOpenStatus = true;
+          }
+        }
+      } else {
+        alertsOpenStatus = true;
+      }
+    });
+  }
+
+  return alertsOpenStatus;
+}
+
+export default checkAlertsOpenStatus;

--- a/src/utils/filterByOpenNow.js
+++ b/src/utils/filterByOpenNow.js
@@ -1,28 +1,9 @@
-/*function getDateWithUTCOffset(inputTzOffset){
-  var now = new Date(); // get the current time
-
-  var currentTzOffset = -now.getTimezoneOffset() / 60 // in hours, i.e. -4 in NY
-  var deltaTzOffset = inputTzOffset - currentTzOffset; // timezone diff
-
-  var nowTimestamp = now.getTime(); // get the number of milliseconds since unix epoch
-  var deltaTzOffsetMilli = deltaTzOffset * 1000 * 60 * 60; // convert hours to milliseconds (tzOffsetMilli*1000*60*60)
-  var outputDate = new Date(nowTimestamp + deltaTzOffsetMilli) // your new Date object with the timezone offset applied.
-
-  return outputDate;
-}
-*/
 const { zonedTimeToUtc, utcToZonedTime, format } = require('date-fns-tz');
 var parseISO = require('date-fns/parseISO');
 
 function filterByOpenNow(locations) {
   const tz = 'America/New_York';
-  //const tz = 'Europe/Berlin';
-  //const utcToday = utcToZonedTime(new Date(), tz);
-  //const formated = format(utcToday, 'yyyy-MM-dd HH:mm:ss', { timeZone: tz });
-  //console.log('formated: ' + formated);
-
   const today = new Date();
-  //console.log('today: ' + today);
 
   // Get the current time, in format 13:56
   // Force timezone to new york.
@@ -54,22 +35,36 @@ function filterByOpenNow(locations) {
         // Check if closed_for key exists
         // If so, set the status to false.
         if ('closed_for' in alert) {
-
-          // @TODO Add check to compare alert.applies.start + alert.applies.end to today.
+          // Compare alert.applies.start + alert.applies.end to today.
           //
           // Refinery Format:
           // 2020-07-08T00:00:00-04:00 -- 2030-07-09T00:00:00-04:00
           //
           // @SEE https://github.com/NYPL/locations-app/search?q=applies.start&unscoped_q=applies.start
+          //
+          if (alert.applies.start && alert.applies.end) {
+            // Get today date only
+            const utcToday = utcToZonedTime(new Date(), tz);
+            const todayFormatted = format(utcToday, 'yyyy-MM-dd', { timeZone: tz });
+            console.log('todayFormatted: ' + todayFormatted);
 
-          const utcToday = utcToZonedTime(new Date(), tz);
-          const todayFormatted = format(utcToday, 'yyyy-MM-dd', { timeZone: tz });
-          console.log('todayFormatted: ' + todayFormatted);
+            // Get start day
+            // We strip off incorrect offset added.
+            const startDay = format(parseISO(alert.applies.start.replace('-04:00', '')), 'yyyy-MM-dd', { timeZone: tz });
+            console.log('startDay: ' + startDay);
 
-          const startDay = format(parseISO(alert.applies.start), 'yyyy-MM-dd', { timeZone: tz });
-          console.log('startDay: ' + startDay);
+            // Get end day
+            // We strip off incorrect offset added.
+            const endDay = format(parseISO(alert.applies.end.replace('-04:00', '')), 'yyyy-MM-dd', { timeZone: tz });
+            console.log('endDay: ' + endDay);
 
-          alertsOpenStatus = false;
+            // Compare startDay, endDay against today
+            if (todayFormatted != startDay && todayFormatted <= endDay) {
+              alertsOpenStatus = false;
+            } else {
+              alertsOpenStatus = true;
+            }
+          }
         } else {
           alertsOpenStatus = true;
         }

--- a/src/utils/filterByOpenNow.js
+++ b/src/utils/filterByOpenNow.js
@@ -1,5 +1,29 @@
+/*function getDateWithUTCOffset(inputTzOffset){
+  var now = new Date(); // get the current time
+
+  var currentTzOffset = -now.getTimezoneOffset() / 60 // in hours, i.e. -4 in NY
+  var deltaTzOffset = inputTzOffset - currentTzOffset; // timezone diff
+
+  var nowTimestamp = now.getTime(); // get the number of milliseconds since unix epoch
+  var deltaTzOffsetMilli = deltaTzOffset * 1000 * 60 * 60; // convert hours to milliseconds (tzOffsetMilli*1000*60*60)
+  var outputDate = new Date(nowTimestamp + deltaTzOffsetMilli) // your new Date object with the timezone offset applied.
+
+  return outputDate;
+}
+*/
+const { zonedTimeToUtc, utcToZonedTime, format } = require('date-fns-tz');
+var parseISO = require('date-fns/parseISO');
+
 function filterByOpenNow(locations) {
+  const tz = 'America/New_York';
+  //const tz = 'Europe/Berlin';
+  //const utcToday = utcToZonedTime(new Date(), tz);
+  //const formated = format(utcToday, 'yyyy-MM-dd HH:mm:ss', { timeZone: tz });
+  //console.log('formated: ' + formated);
+
   const today = new Date();
+  //console.log('today: ' + today);
+
   // Get the current time, in format 13:56
   // Force timezone to new york.
   const nowTime = today.toLocaleTimeString('en-US', {
@@ -30,6 +54,21 @@ function filterByOpenNow(locations) {
         // Check if closed_for key exists
         // If so, set the status to false.
         if ('closed_for' in alert) {
+
+          // @TODO Add check to compare alert.applies.start + alert.applies.end to today.
+          //
+          // Refinery Format:
+          // 2020-07-08T00:00:00-04:00 -- 2030-07-09T00:00:00-04:00
+          //
+          // @SEE https://github.com/NYPL/locations-app/search?q=applies.start&unscoped_q=applies.start
+
+          const utcToday = utcToZonedTime(new Date(), tz);
+          const todayFormatted = format(utcToday, 'yyyy-MM-dd', { timeZone: tz });
+          console.log('todayFormatted: ' + todayFormatted);
+
+          const startDay = format(parseISO(alert.applies.start), 'yyyy-MM-dd', { timeZone: tz });
+          console.log('startDay: ' + startDay);
+
           alertsOpenStatus = false;
         } else {
           alertsOpenStatus = true;

--- a/src/utils/filterByOpenNow.js
+++ b/src/utils/filterByOpenNow.js
@@ -23,7 +23,8 @@ function filterByOpenNow(locations) {
         if (
           // Check for not null.
           hoursItem.open !== null && hoursItem.close !== null
-          // @TODO Check alerts: location._embedded.alerts for closings.
+          // Check alerts: location._embedded.alerts for closings.
+          && location._embedded.alerts === undefined || location._embedded.alerts.length === 0
           // Check for extended closing.
           && location.open
           // Check open/closed hours against now time.


### PR DESCRIPTION
[Jira Ticket](http://jira.nypl.org/browse/RENO-1677)

**This PR does the following:**
- Updates the `filterByOpenNow()` util to use refinery alert data correctly
- Checks for "alert closings" and should ignore "non-closing alerts"
- Updates Location component to display "Location is temporarily closed" status badge.

**Notes on the data returned**
Refinery locations has 92 locations. Around 30 should be "open", the rest are closed.
Location Finder is currently returning 28, which might correct?

### Review Steps:
- [x] Pull in latest branch code
- [x] npm install
- [x] npm run dev
- [x] Goto local app: http://localhost:3000/location-finder
- [x] Search for a location and check "Open Now"
- [ ] You should get 28 results (I think this is correct)
- [ ] Review logic in `checkAlertsOpenStatus()` function.

### Front End Review Steps:
- [ ] View [Example](http://localhost:3000/)
