### PR TITLE
Fix for CORS Preflight Issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9423,6 +9423,11 @@
         "raw-body": "2.3.2"
       }
     },
+    "micro-cors": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/micro-cors/-/micro-cors-0.1.1.tgz",
+      "integrity": "sha512-6WqIahA5sbQR1Gjexp1VuWGFDKbZZleJb/gy1khNGk18a6iN1FdTcr3Q8twaxkV5H94RjxIBjirYbWCehpMBFw=="
+    },
     "micromatch": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "date-fns-tz": "^1.0.10",
     "graphql": "^14.7.0",
     "graphql-tag": "2.10.3",
+    "micro-cors": "^0.1.1",
     "next": "latest",
     "next-transpile-modules": "^4.1.0",
     "prop-types": "^15.6.2",

--- a/src/pages/api/graphql.js
+++ b/src/pages/api/graphql.js
@@ -2,6 +2,7 @@ import { ApolloServer } from 'apollo-server-micro';
 import { schema } from '../../apollo/server/schema';
 import DrupalApi from './../../apollo/server/datasources/DrupalApi';
 import RefineryApi from './../../apollo/server/datasources/RefineryApi';
+import Cors from 'micro-cors';
 
 const apolloServer = new ApolloServer({
   schema,
@@ -19,4 +20,24 @@ export const config = {
   },
 }
 
-export default apolloServer.createHandler({ path: '/api/graphql' });
+/*
+ * There's an issue with apollo-server-micro where OPTIONS method
+ * will return with the wrong status code.
+ *
+ * This only happens if you try to make a cross-origin req to the
+ * /api/graphql route.
+ *
+ * @SEE https://github.com/apollographql/apollo-server/issues/2473
+ *
+*/
+// Set cors policy.
+const cors = Cors({
+  allowMethods: ['POST', 'OPTIONS']
+});
+
+export default cors((req, res) => {
+  if (req.method === 'OPTIONS') {
+    return res.end();
+  }
+  return apolloServer.createHandler({ path: '/api/graphql' })(req, res);
+})


### PR DESCRIPTION
[Jira Ticket](http://jira.nypl.org/browse/RENO-XXX)
[Metronome](http://themetronome.co/components/XXX/?fresh=true)

**This PR does the following:**
- Fixes `has been blocked by CORS policy: Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.`
- Allows other domains to access `api/graphql` endpoint

### Review Steps:
- [ ] Example step one

### Front End Review Steps:
- [ ] View [Example](http://localhost:3000/)
