### PR TITLE
RENO-1642: Remove Pagination From Desktop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Adds custom skeleton loader
 * Adds link to google maps info window bubble
 * Additional filter capabilities for autosuggest including zipcode + locality
+* Removes Pagination From Desktop or any browser width 600px or more.
 
 ### v0.1.0 [2020-09-14] Initial Release
 ---------------------------------------

--- a/src/components/location-finder/Locations/Locations.js
+++ b/src/components/location-finder/Locations/Locations.js
@@ -23,8 +23,18 @@ import * as DS from '@nypl/design-system-react-components';
 import Location from './../Location';
 import LoadingSkeleton from './../../shared/LoadingSkeleton';
 import LocationsPagination from './LocationsPagination';
+// Hooks
+import useWindowSize from './../../../hooks/useWindowSize';
 
 function Locations() {
+  // Special handling for pagination on desktop
+  const windowSize = useWindowSize();
+  // Set limit based on window size, to disable pagination for desktop only.
+  let limit = 300;
+  if (windowSize < 600) {
+    limit = 10;
+  }
+
   // Redux
   const {
     searchQuery,
@@ -40,7 +50,6 @@ function Locations() {
   // Apollo
   const searchGeoLat = searchQueryGeoLat ? searchQueryGeoLat : null;
   const searchGeoLng = searchQueryGeoLng ? searchQueryGeoLng : null;
-  const limit = 10;
   // Query for data.
   const { loading, error, data, networkStatus, fetchMore } = useQuery(
     LOCATIONS_QUERY, {
@@ -57,7 +66,7 @@ function Locations() {
     }
   );
 
-  // Side effect to dispatch redux action to set the locations count.
+  // Side effect to dispatch redux action to set pagination redux state.
   useEffect(() => {
     if (data) {
       // Dispatch redux action

--- a/src/components/location-finder/Locations/LocationsPagination.js
+++ b/src/components/location-finder/Locations/LocationsPagination.js
@@ -102,7 +102,7 @@ function LocationsPagination({ limit }) {
     }));
   }
 
-  if (pageCount) {
+  if (pageCount > 1) {
     return (
       <DS.Pagination
         nextPage={NextButton(pageNumber, pageCount)}

--- a/src/hooks/useWindowSize.js
+++ b/src/hooks/useWindowSize.js
@@ -1,0 +1,28 @@
+import { useState, useEffect } from 'react';
+
+function useWindowSize() {
+  const isWindowClient = typeof window === 'object';
+
+  const [windowSize, setWindowSize] = useState(
+    isWindowClient ? window.innerWidth : undefined
+  );
+
+  useEffect(() => {
+    // Handler called on change of the screen resize
+    function setSize() {
+      setWindowSize(window.innerWidth);
+    }
+
+    if (isWindowClient) {
+      // Add the window resize listener
+      window.addEventListener('resize', setSize);
+
+      // Remove the listener
+      return () => window.removeEventListener('resize', setSize);
+    }
+  }, [isWindowClient, setWindowSize]);
+
+  return windowSize;
+}
+
+export default useWindowSize;


### PR DESCRIPTION
[Jira Ticket](http://jira.nypl.org/browse/RENO-1642)

**This PR does the following:**
- Adds a custom hook called `useWindowSize()` that calculates the window size of the browser.
- Using this hook, disables pagination for desktop screens by setting the `limit` to get all results instead of 10.

### Review Steps:
- [ ] Pull in the code and start the app
- [ ] For screens smaller than 600px, pagination should appear, otherwise pagination is disabled.

### Front End Review Steps:
- [ ] View [Example](http://localhost:3000/locations)
