### PR TITLE
RENO-1633: Add Focus to Location Anchor When Map Marker is Clicked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Adds v2 of the NYPL advocacy.js (which removes the jQuery dependency) to support OptinMonster campaigns
 * Fix for Future Closings Incorrectly Displayed As Current Closings
 * Move Refinery endpoint definition to set-env script
+* Add Focus to Location Anchor When Map Marker is Clicked
 
 ### v0.1.1 [2020-10-06] Location Finder Improvements
 -------------------------------------------

--- a/src/components/location-finder/Location/index.js
+++ b/src/components/location-finder/Location/index.js
@@ -11,7 +11,7 @@ import useWindowSize from './../../../hooks/useWindowSize';
 function Location({ location }) {
   // Redux dispatch
   const dispatch = useDispatch();
-  
+
   const windowSize = useWindowSize();
 
   // Address formatting.
@@ -85,7 +85,7 @@ function Location({ location }) {
   return (
     <div className='location'>
       <DS.Heading
-        id={location.id}
+        id={ `lid-${location.id}` }
         level={2}
         className='location__name'
       >

--- a/src/components/location-finder/Map/index.js
+++ b/src/components/location-finder/Map/index.js
@@ -122,7 +122,10 @@ function Map() {
 
     // Scroll to location on list when map marker is clicked for desktop only.
     if (windowSize >= 600) {
-      document.getElementById(location.id).scrollIntoView({
+      // Set focus
+      document.querySelector(`#lid-${location.id} a`).focus();
+      // Scroll into view.
+      document.getElementById(`lid-${location.id}`).scrollIntoView({
         alignToTop: false,
         behavior: 'smooth'
       });


### PR DESCRIPTION
[Jira Ticket](http://jira.nypl.org/browse/RENO-1633)

**This PR does the following:**
- When map marker is clicked, in addition to scrolling location into view, focus is added to the location link.
- Updated location heading IDs to be prefixed with `lid-` since IDs should not start with numbers (i.e, 96th-street, 125th-street, etc)

### Review Steps:
- [ ] Example step one

### Front End Review Steps:
- [ ] View [Example](http://localhost:3000/)
