### PR TITLE
RENO-1802 - Today's Hours display stripping out minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### v0.1.2 [ ] Location Finder Improvements
 -------------------------------------------
+* Fix for Today's Hours display stripping out minutes
 * Changes the closed message from "no hours available" to "closed"
 * Improves "View on Map" functionality for mobile.
 * Removed horizontal scroll bar on layout

--- a/src/components/location-finder/Location/index.js
+++ b/src/components/location-finder/Location/index.js
@@ -11,7 +11,7 @@ import useWindowSize from './../../../hooks/useWindowSize';
 function Location({ location }) {
   // Redux dispatch
   const dispatch = useDispatch();
-  
+
   const windowSize = useWindowSize();
 
   // Address formatting.
@@ -74,12 +74,17 @@ function Location({ location }) {
     const startHoursOnly = +start.substr(0, 2);
     const startHours = (startHoursOnly % 12) || 12;
     const startMeridiem = (startHoursOnly < 12 || startHoursOnly === 24) ? "AM" : "PM";
+    const startMinutesOnly = start.substr(3, 2);
+    const startHoursFinal = (startMinutesOnly != 0) ? (startHours + ':' + startMinutesOnly) : startHours;
+
     // End hour
     const endHoursOnly = +end.substr(0, 2);
     const endHours = (endHoursOnly % 12) || 12;
     const endMeridiem = (endHoursOnly < 12 || endHoursOnly === 24) ? "AM" : "PM";
+    const endMinutesOnly = end.substr(3, 2);
+    const endHoursFinal = (endMinutesOnly != 0) ? (endHours + ':' + endMinutesOnly) : endHours;
 
-    return `${startHours}${startMeridiem}–${endHours}${endMeridiem}`;
+    return `${startHoursFinal}${startMeridiem}–${endHoursFinal}${endMeridiem}`;
   }
 
   return (


### PR DESCRIPTION
[Jira Ticket](http://jira.nypl.org/browse/RENO-1802)

**This PR does the following:**
- Fixed "Today's hours" display to accommodate for hours having "14:45" format and would display the as "2:45pm"

### Review Steps:
- [ ] Review example

### Front End Review Steps:
- [ ] View [Example](http://localhost:3000/)
