### PR TITLE
RENO-1830: All Day Closings Accommodate Hours + Mins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 -----------
 
 ### v0.1.4 [ ??? ] Location Finder Improvements
--------------------------------------------
-* Light refactor of location components and basic tests for Location components
+-----------------------------------------------
+* Light refactor of location components and basic tests for Location components.
+* Code improvements for handling of all day closings to accommodate hours, minutes.
+* Added unit tests for checkAlertsOpenStatus.
+* Replaced date-fns and date-fns-tz with DayJS for handling + comparing dates.
 
 ### v0.1.3 [2020-10-28] Hotfixes alert status logic
 ---------------------------------------------------

--- a/package-lock.json
+++ b/package-lock.json
@@ -5651,6 +5651,11 @@
       "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.0.10.tgz",
       "integrity": "sha512-cHQAz0/9uDABaUNDM80Mj1FL4ODlxs1xEY4b0DQuAooO2UdNKvDkNbV8ogLnxLbv02Ru1HXFcot0pVvDRBgptg=="
     },
+    "dayjs": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.9.4.tgz",
+      "integrity": "sha512-ABSF3alrldf7nM9sQ2U+Ln67NRwmzlLOqG7kK03kck0mw3wlSSEKv/XhKGGxUjQcS57QeiCyNdrFgtj9nWlrng=="
+    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5641,16 +5641,6 @@
         }
       }
     },
-    "date-fns": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.16.0.tgz",
-      "integrity": "sha512-DWTRyfOA85sZ4IiXPHhiRIOs3fW5U6Msrp+gElXARa6EpoQTXPyHQmh7hr+ssw2nx9FtOQWnAMJKgL5vaJqILw=="
-    },
-    "date-fns-tz": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.0.10.tgz",
-      "integrity": "sha512-cHQAz0/9uDABaUNDM80Mj1FL4ODlxs1xEY4b0DQuAooO2UdNKvDkNbV8ogLnxLbv02Ru1HXFcot0pVvDRBgptg=="
-    },
     "dayjs": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.9.4.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "breakpoint-sass": "2.7.0",
     "date-fns": "^2.16.0",
     "date-fns-tz": "^1.0.10",
+    "dayjs": "^1.9.4",
     "graphql": "^14.7.0",
     "graphql-tag": "2.10.3",
     "micro-cors": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,6 @@
     "apollo-server-micro": "^2.16.1",
     "apollo-utilities": "^1.3.2",
     "breakpoint-sass": "2.7.0",
-    "date-fns": "^2.16.0",
-    "date-fns-tz": "^1.0.10",
     "dayjs": "^1.9.4",
     "graphql": "^14.7.0",
     "graphql-tag": "2.10.3",

--- a/src/apollo/server/datasources/RefineryApi.js
+++ b/src/apollo/server/datasources/RefineryApi.js
@@ -4,6 +4,13 @@ import sortByDistance from './../../../utils/sortByDistance';
 import filterByOpenNow from './../../../utils/filterByOpenNow';
 import checkAlertsOpenStatus from './../../../utils/checkAlertsOpenStatus';
 import sortByName from './../../../utils/sortByName';
+// Dayjs
+const dayjs = require('dayjs');
+// Timezone
+var utc = require('dayjs/plugin/utc');
+var timezone = require('dayjs/plugin/timezone');
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 class RefineryApi extends RESTDataSource {
   constructor() {
@@ -41,7 +48,11 @@ class RefineryApi extends RESTDataSource {
     });
 
     // Alerts
-    const alertsOpenStatus = checkAlertsOpenStatus(location);
+    const timeZone = 'America/New_York';
+    let now = dayjs().tz(timeZone);
+    const today = now.format();
+
+    const alertsOpenStatus = checkAlertsOpenStatus(today, location);
 
     // Open status
     let open = false;

--- a/src/apollo/server/datasources/RefineryApi.js
+++ b/src/apollo/server/datasources/RefineryApi.js
@@ -20,6 +20,10 @@ class RefineryApi extends RESTDataSource {
 
   // Tidy up the response from Refinery.
   locationNormalizer(location) {
+    // Create a dayJS date object.
+    const timeZone = 'America/New_York';
+    let now = dayjs().tz(timeZone);
+
     let wheelchairAccess;
     switch(location.access) {
       case 'Fully Accessible':
@@ -34,22 +38,19 @@ class RefineryApi extends RESTDataSource {
     }
 
     // Today hours
-    const currentDate = new Date();
     const weekDayKeys = new Array('Sun.', 'Mon.', 'Tue.', 'Wed.', 'Thu.', 'Fri.', 'Sat.');
 
     let todayHoursStart;
     let todayHoursEnd;
 
     location.hours.regular.map(item => {
-      if (weekDayKeys[currentDate.getDay()] === item.day) {
+      if (weekDayKeys[now.day()] === item.day) {
         todayHoursStart = item.open;
         todayHoursEnd = item.close;
       }
     });
 
-    // Alerts
-    const timeZone = 'America/New_York';
-    let now = dayjs().tz(timeZone);
+    // Format datetime in ISO8601, i.e, 2020-10-27T12:00:00-04:00.
     const today = now.format();
     // Check open status based on alerts.
     const alertsOpenStatus = checkAlertsOpenStatus(today, location._embedded.alerts);
@@ -103,7 +104,7 @@ class RefineryApi extends RESTDataSource {
   async getAllLocations(args) {
     const response = await this.get('/locations/v1.0/locations');
 
-    //
+    // Create a dayJS date object.
     const timeZone = 'America/New_York';
     let now = dayjs().tz(timeZone);
 

--- a/src/apollo/server/datasources/RefineryApi.js
+++ b/src/apollo/server/datasources/RefineryApi.js
@@ -4,9 +4,9 @@ import sortByDistance from './../../../utils/sortByDistance';
 import filterByOpenNow from './../../../utils/filterByOpenNow';
 import checkAlertsOpenStatus from './../../../utils/checkAlertsOpenStatus';
 import sortByName from './../../../utils/sortByName';
-// Dayjs
+// DayJS
 const dayjs = require('dayjs');
-// Timezone
+// DayJS timezone
 var utc = require('dayjs/plugin/utc');
 var timezone = require('dayjs/plugin/timezone');
 dayjs.extend(utc);
@@ -51,8 +51,8 @@ class RefineryApi extends RESTDataSource {
     const timeZone = 'America/New_York';
     let now = dayjs().tz(timeZone);
     const today = now.format();
-
-    const alertsOpenStatus = checkAlertsOpenStatus(today, location);
+    // Check open status based on alerts.
+    const alertsOpenStatus = checkAlertsOpenStatus(today, location._embedded.alerts);
 
     // Open status
     let open = false;
@@ -103,6 +103,10 @@ class RefineryApi extends RESTDataSource {
   async getAllLocations(args) {
     const response = await this.get('/locations/v1.0/locations');
 
+    //
+    const timeZone = 'America/New_York';
+    let now = dayjs().tz(timeZone);
+
     if (Array.isArray(response.locations)) {
       let results;
       let totalResultsCount = Object.keys(response.locations).length;
@@ -120,7 +124,7 @@ class RefineryApi extends RESTDataSource {
         // Open now only.
         if (args.filter.openNow) {
           console.log('filter: open now only');
-          results = filterByOpenNow(response.locations).sort(sortByName).map(location =>
+          results = filterByOpenNow(now, response.locations).sort(sortByName).map(location =>
             this.locationNormalizer(location)
           );
           // We're removing locations from results, so set the new total results count.
@@ -136,7 +140,7 @@ class RefineryApi extends RESTDataSource {
           && args.sortByDistance.originLng
         ) {
           console.log('both!');
-          results = sortByDistance(args.sortByDistance, filterByOpenNow(response.locations)).map(location =>
+          results = sortByDistance(args.sortByDistance, filterByOpenNow(now, response.locations)).map(location =>
             this.locationNormalizer(location)
           );
           // We're removing locations from results, so set the new total results count.

--- a/src/utils/checkAlertsOpenStatus.js
+++ b/src/utils/checkAlertsOpenStatus.js
@@ -1,23 +1,17 @@
 const dayjs = require('dayjs');
 var isBetween = require('dayjs/plugin/isBetween');
 dayjs.extend(isBetween);
-// Timezone
-/*var utc = require('dayjs/plugin/utc');
-var timezone = require('dayjs/plugin/timezone');
-dayjs.extend(utc)
-dayjs.extend(timezone)
-*/
 
-function checkAlertsOpenStatus(today, location) {
-  /*const timeZone = 'America/New_York';
-  let now = dayjs().tz(timeZone);
-  const today = now.format();
-  */
-  //console.log('today: ' + today);
-  const alerts = location._embedded.alerts;
-  //console.log(alerts);
-
+/**
+ * Determines if a location is open by comparing today to alerts & closings data.
+ *
+ * @param {date} today - current datetime in ISO8601: 2020-10-27T12:00:00-04:00.
+ * @param {object} alerts - an object of alerts & closings.
+ * @return {boolean} alertsOpenStatus - true = open | false = closed
+ */
+function checkAlertsOpenStatus(today, alerts) {
   let alertsOpenStatus = true;
+
   // Check for any alerts.
   if (alerts === undefined || alerts.length === 0) {
     // No alerts, so set this status to true.
@@ -29,20 +23,12 @@ function checkAlertsOpenStatus(today, location) {
       // Check if closed_for key exists
       if ('closed_for' in alert) {
         // Compare alert.applies.start + alert.applies.end to today.
-        //
-        // Refinery Format:
-        // 2020-07-08T00:00:00-04:00 -- 2030-07-09T00:00:00-04:00
-        //
-        // @SEE https://github.com/NYPL/locations-app/search?q=applies.start&unscoped_q=applies.start
-        //
         if (alert.applies.start && alert.applies.end) {
           // Dayjs version
           if (dayjs(today).isBetween(alert.applies.start, alert.applies.end)) {
             alertsOpenStatus = false;
           }
         }
-      } else {
-        alertsOpenStatus = true;
       }
     });
   }

--- a/src/utils/checkAlertsOpenStatus.js
+++ b/src/utils/checkAlertsOpenStatus.js
@@ -5,8 +5,8 @@ dayjs.extend(isBetween);
 /**
  * Determines if a location is open by comparing today to alerts & closings data.
  *
- * @param {date} today - current datetime in ISO8601: 2020-10-27T12:00:00-04:00.
- * @param {object} alerts - an object of alerts & closings.
+ * @param {date} today - current datetime in ISO8601, i.e, 2020-10-27T12:00:00-04:00.
+ * @param {object} alerts - an object of alerts & closings data.
  * @return {boolean} alertsOpenStatus - true = open | false = closed
  */
 function checkAlertsOpenStatus(today, alerts) {
@@ -22,9 +22,9 @@ function checkAlertsOpenStatus(today, alerts) {
     alerts.map(alert => {
       // Check if closed_for key exists
       if ('closed_for' in alert) {
-        // Compare alert.applies.start + alert.applies.end to today.
+        // Check for start and end values
         if (alert.applies.start && alert.applies.end) {
-          // Dayjs version
+          // Compare alert.applies.start + alert.applies.end to today.
           if (dayjs(today).isBetween(alert.applies.start, alert.applies.end)) {
             alertsOpenStatus = false;
           }

--- a/src/utils/checkAlertsOpenStatus.js
+++ b/src/utils/checkAlertsOpenStatus.js
@@ -1,9 +1,21 @@
-const { zonedTimeToUtc, utcToZonedTime, format } = require('date-fns-tz');
-var parseISO = require('date-fns/parseISO');
+const dayjs = require('dayjs');
+var isBetween = require('dayjs/plugin/isBetween');
+dayjs.extend(isBetween);
+// Timezone
+/*var utc = require('dayjs/plugin/utc');
+var timezone = require('dayjs/plugin/timezone');
+dayjs.extend(utc)
+dayjs.extend(timezone)
+*/
 
-function checkAlertsOpenStatus(location) {
+function checkAlertsOpenStatus(today, location) {
+  /*const timeZone = 'America/New_York';
+  let now = dayjs().tz(timeZone);
+  const today = now.format();
+  */
+  //console.log('today: ' + today);
   const alerts = location._embedded.alerts;
-  const tz = 'America/New_York';
+  //console.log(alerts);
 
   let alertsOpenStatus = true;
   // Check for any alerts.
@@ -24,24 +36,8 @@ function checkAlertsOpenStatus(location) {
         // @SEE https://github.com/NYPL/locations-app/search?q=applies.start&unscoped_q=applies.start
         //
         if (alert.applies.start && alert.applies.end) {
-          // Get today date only
-          const utcToday = utcToZonedTime(new Date(), tz);
-          const today = format(utcToday, 'yyyy-MM-dd', { timeZone: tz });
-          //console.log('today: ' + today);
-
-          // Get start day
-          // We strip off incorrect offset added.
-          const startDay = format(parseISO(alert.applies.start.replace('-04:00', '')), 'yyyy-MM-dd', { timeZone: tz });
-          //console.log('startDay: ' + startDay);
-
-          // Get end day
-          // We strip off incorrect offset added.
-          const endDay = format(parseISO(alert.applies.end.replace('-04:00', '')), 'yyyy-MM-dd', { timeZone: tz });
-          //console.log('endDay: ' + endDay);
-
-          // Compare startDay, endDay against today
-          if (today >= startDay && today < endDay) {
-            // Set temporary closed status.
+          // Dayjs version
+          if (dayjs(today).isBetween(alert.applies.start, alert.applies.end)) {
             alertsOpenStatus = false;
           }
         }

--- a/src/utils/checkAlertsOpenStatus.test.js
+++ b/src/utils/checkAlertsOpenStatus.test.js
@@ -1,0 +1,111 @@
+import checkAlertsOpenStatus from './checkAlertsOpenStatus';
+
+/**
+ * Temporary closing, one.
+ *
+ * today: October 27, 12:00pm
+ * closing start: October 27, 2020 10:15am
+ * closing end: October 27, 2021, 10:15am
+ *
+ * Expected: Closed (false)
+ */
+let today = '2020-10-27T12:00:00-04:00';
+const alertsTempClosingOne = [
+  {
+    id: '11',
+    scope: 'location',
+    msg: '<p>Temporarily closed due to COVID-19.</p>\n',
+    display: {
+      start: '2020-10-27T10:15:00-04:00',
+      end: '2021-10-27T10:15:00-04:00'
+    },
+    closed_for: 'Temporarily closed due to COVID-19.\n',
+    applies: {
+      start: '2020-10-27T10:15:00-04:00',
+      end: '2021-10-27T10:15:00-04:00'
+    }
+  }
+];
+
+test('Temporary closing, one', () => {
+  expect(checkAlertsOpenStatus(today, alertsTempClosingOne)).toBe(false);
+});
+
+/**
+ * Temporary closing, many.
+ *
+ * today: October 27, 12:00pm
+ * closing start: October 27, 2020 10:15am
+ * closing end: October 27, 2021, 10:15am
+ *
+ *
+ *
+ *
+ * Expected: Closed (false)
+ */
+
+const alertsTempClosingMany = [
+  {
+    id: '11',
+    scope: 'location',
+    msg: '<p>Temporarily closed due to COVID-19.</p>\n',
+    display: {
+      start: '2020-10-27T10:15:00-04:00',
+      end: '2021-10-27T10:15:00-04:00'
+    },
+    closed_for: 'Temporarily closed due to COVID-19.\n',
+    applies: {
+      start: '2020-10-27T10:15:00-04:00',
+      end: '2021-10-27T10:15:00-04:00'
+    }
+  },
+  {
+    id: "9",
+    scope: "location",
+    display: {
+      start: "2020-10-21T09:00:00-04:00",
+      end: "2020-10-30T00:00:00-04:00"
+    },
+    closed_for: "Library specific closing.",
+    applies: {
+      start: "2020-10-28T00:00:00-04:00",
+      end: "2020-10-29T23:59:00-04:00"
+    }
+  }
+];
+
+test('Temporary closing, many', () => {
+  expect(checkAlertsOpenStatus(today, alertsTempClosingMany)).toBe(false);
+});
+
+
+/**
+ * Test that hours and mins in alert datetime is respected.
+ *
+ * today: October 27, 12:00pm
+ * closing start: October 27, 2020 12:00pm
+ * closing end: October 28, 2020, 12:15pm
+ *
+ * Expected: Open (true). Closing does not start until 12:01pm
+ */
+today = '2020-10-27T12:00:00-04:00';
+const alertsHoursMins = [
+  {
+    id: '11',
+    scope: 'location',
+    msg: 'Single day closing with specific hours.',
+    display: {
+      start: '2020-10-27T12:01:00-04:00',
+      end: '2021-10-27T12:01:00-04:00'
+    },
+    closed_for: 'Single day closing with specific hours.',
+    applies: {
+      start: '2020-10-27T12:01:00-04:00',
+      end: '2021-10-28T12:01:00-04:00'
+    }
+  }
+];
+
+test('Alerts hours and minutes are respected', () => {
+  expect(checkAlertsOpenStatus(today, alertsHoursMins)).toBe(true);
+});

--- a/src/utils/checkAlertsOpenStatus.test.js
+++ b/src/utils/checkAlertsOpenStatus.test.js
@@ -87,8 +87,8 @@ describe('checkAlertsOpenStatus', () => {
    * Test that hours and mins in alert are accounted for, inactive.
    *
    * today: October 27, 12:00pm
-   * closing start: October 27, 2020 12:00pm
-   * closing end: October 28, 2020, 12:15pm
+   * closing start: October 27, 2020 12:01pm
+   * closing end: October 28, 2021, 12:01pm
    *
    * Expected: Open (true). Closing does not start until 12:01pm
    */
@@ -119,8 +119,8 @@ describe('checkAlertsOpenStatus', () => {
    * Test that hours and mins in alert is accounted for, active.
    *
    * today: October 27, 12:05pm
-   * closing start: October 27, 2020 12:00pm
-   * closing end: October 28, 2021, 12:15pm
+   * closing start: October 27, 2020 12:01pm
+   * closing end: October 28, 2021, 12:01pm
    *
    * Expected: Closed (false). 12:05pm and the location is closed.
    */

--- a/src/utils/checkAlertsOpenStatus.test.js
+++ b/src/utils/checkAlertsOpenStatus.test.js
@@ -1,111 +1,149 @@
 import checkAlertsOpenStatus from './checkAlertsOpenStatus';
 
-/**
- * Temporary closing, one.
- *
- * today: October 27, 12:00pm
- * closing start: October 27, 2020 10:15am
- * closing end: October 27, 2021, 10:15am
- *
- * Expected: Closed (false)
- */
-let today = '2020-10-27T12:00:00-04:00';
-const alertsTempClosingOne = [
-  {
-    id: '11',
-    scope: 'location',
-    msg: '<p>Temporarily closed due to COVID-19.</p>\n',
-    display: {
-      start: '2020-10-27T10:15:00-04:00',
-      end: '2021-10-27T10:15:00-04:00'
-    },
-    closed_for: 'Temporarily closed due to COVID-19.\n',
-    applies: {
-      start: '2020-10-27T10:15:00-04:00',
-      end: '2021-10-27T10:15:00-04:00'
+describe('checkAlertsOpenStatus', () => {
+  /**
+   * Temporary closing, one.
+   *
+   * today: October 27, 12:00pm
+   * closing start: October 27, 2020 10:15am
+   * closing end: October 27, 2021, 10:15am
+   *
+   * Expected: Closed (false)
+   */
+  const alertsTempClosingOne = [
+    {
+      id: '11',
+      scope: 'location',
+      msg: '<p>Temporarily closed due to COVID-19.</p>\n',
+      display: {
+        start: '2020-10-27T10:15:00-04:00',
+        end: '2021-10-27T10:15:00-04:00'
+      },
+      closed_for: 'Temporarily closed due to COVID-19.\n',
+      applies: {
+        start: '2020-10-27T10:15:00-04:00',
+        end: '2021-10-27T10:15:00-04:00'
+      }
     }
-  }
-];
+  ];
 
-test('Temporary closing, one', () => {
-  expect(checkAlertsOpenStatus(today, alertsTempClosingOne)).toBe(false);
-});
+  test('One active temporary closing should return false.', () => {
+    expect(
+      checkAlertsOpenStatus('2020-10-27T12:00:00-04:00', alertsTempClosingOne)
+    ).toBe(false);
+  });
 
-/**
- * Temporary closing, many.
- *
- * today: October 27, 12:00pm
- * closing start: October 27, 2020 10:15am
- * closing end: October 27, 2021, 10:15am
- *
- *
- *
- *
- * Expected: Closed (false)
- */
-
-const alertsTempClosingMany = [
-  {
-    id: '11',
-    scope: 'location',
-    msg: '<p>Temporarily closed due to COVID-19.</p>\n',
-    display: {
-      start: '2020-10-27T10:15:00-04:00',
-      end: '2021-10-27T10:15:00-04:00'
+  /**
+   * Temporary closing, many.
+   *
+   * today: October 27, 2020, 12:00pm
+   *
+   * closing start: October 27, 2020 10:15am
+   * closing end: October 27, 2021, 10:15am
+   *
+   * closing 2 start: October 28, 2020, 12:00pm
+   * closing 2 end: October 29, 2020, 11:59pm
+   *
+   * Expected: Closed (false)
+   */
+  const alertsTempClosingMany = [
+    {
+      id: '11',
+      scope: 'location',
+      msg: '<p>Temporarily closed due to COVID-19.</p>\n',
+      display: {
+        start: '2020-10-27T10:15:00-04:00',
+        end: '2021-10-27T10:15:00-04:00'
+      },
+      closed_for: 'Temporarily closed due to COVID-19.\n',
+      applies: {
+        start: '2020-10-27T10:15:00-04:00',
+        end: '2021-10-27T10:15:00-04:00'
+      }
     },
-    closed_for: 'Temporarily closed due to COVID-19.\n',
-    applies: {
-      start: '2020-10-27T10:15:00-04:00',
-      end: '2021-10-27T10:15:00-04:00'
+    {
+      id: "9",
+      scope: "location",
+      display: {
+        start: "2020-10-21T09:00:00-04:00",
+        end: "2020-10-30T00:00:00-04:00"
+      },
+      closed_for: "Library specific closing.",
+      applies: {
+        start: "2020-10-28T00:00:00-04:00",
+        end: "2020-10-29T23:59:00-04:00"
+      }
     }
-  },
-  {
-    id: "9",
-    scope: "location",
-    display: {
-      start: "2020-10-21T09:00:00-04:00",
-      end: "2020-10-30T00:00:00-04:00"
-    },
-    closed_for: "Library specific closing.",
-    applies: {
-      start: "2020-10-28T00:00:00-04:00",
-      end: "2020-10-29T23:59:00-04:00"
+  ];
+
+  test('Many temporary closings, only 1 active, should return false.', () => {
+    expect(
+      checkAlertsOpenStatus('2020-10-27T12:00:00-04:00', alertsTempClosingMany)
+    ).toBe(false);
+  });
+
+
+  /**
+   * Test that hours and mins in alert are accounted for, inactive.
+   *
+   * today: October 27, 12:00pm
+   * closing start: October 27, 2020 12:00pm
+   * closing end: October 28, 2020, 12:15pm
+   *
+   * Expected: Open (true). Closing does not start until 12:01pm
+   */
+  const alertsHoursMins = [
+    {
+      id: '11',
+      scope: 'location',
+      msg: 'Single day closing with specific hours.',
+      display: {
+        start: '2020-10-27T12:01:00-04:00',
+        end: '2021-10-27T12:01:00-04:00'
+      },
+      closed_for: 'Single day closing with specific hours.',
+      applies: {
+        start: '2020-10-27T12:01:00-04:00',
+        end: '2021-10-28T12:01:00-04:00'
+      }
     }
-  }
-];
+  ];
 
-test('Temporary closing, many', () => {
-  expect(checkAlertsOpenStatus(today, alertsTempClosingMany)).toBe(false);
-});
+  test('A single temporary closing with inactive hours should return true.', () => {
+    expect(
+      checkAlertsOpenStatus('2020-10-27T12:00:00-04:00', alertsHoursMins)
+    ).toBe(true);
+  });
 
-
-/**
- * Test that hours and mins in alert datetime is respected.
- *
- * today: October 27, 12:00pm
- * closing start: October 27, 2020 12:00pm
- * closing end: October 28, 2020, 12:15pm
- *
- * Expected: Open (true). Closing does not start until 12:01pm
- */
-today = '2020-10-27T12:00:00-04:00';
-const alertsHoursMins = [
-  {
-    id: '11',
-    scope: 'location',
-    msg: 'Single day closing with specific hours.',
-    display: {
-      start: '2020-10-27T12:01:00-04:00',
-      end: '2021-10-27T12:01:00-04:00'
-    },
-    closed_for: 'Single day closing with specific hours.',
-    applies: {
-      start: '2020-10-27T12:01:00-04:00',
-      end: '2021-10-28T12:01:00-04:00'
+  /**
+   * Test that hours and mins in alert is accounted for, active.
+   *
+   * today: October 27, 12:05pm
+   * closing start: October 27, 2020 12:00pm
+   * closing end: October 28, 2021, 12:15pm
+   *
+   * Expected: Closed (false). 12:05pm and the location is closed.
+   */
+  const alertsHoursMinsActive = [
+    {
+      id: '11',
+      scope: 'location',
+      msg: 'Single day closing with specific hours.',
+      display: {
+        start: '2020-10-27T12:01:00-04:00',
+        end: '2021-10-27T12:01:00-04:00'
+      },
+      closed_for: 'Single day closing with specific hours.',
+      applies: {
+        start: '2020-10-27T12:01:00-04:00',
+        end: '2021-10-28T12:01:00-04:00'
+      }
     }
-  }
-];
+  ];
 
-test('Alerts hours and minutes are respected', () => {
-  expect(checkAlertsOpenStatus(today, alertsHoursMins)).toBe(true);
+  test('A single temporary closing with active hours should return false.', () => {
+    expect(
+      checkAlertsOpenStatus('2020-10-27T12:05:00-04:00', alertsHoursMinsActive)
+    ).toBe(false);
+  });
 });

--- a/src/utils/filterByOpenNow.js
+++ b/src/utils/filterByOpenNow.js
@@ -1,46 +1,21 @@
 import checkAlertsOpenStatus from './checkAlertsOpenStatus';
 
-// Dayjs
-const dayjs = require('dayjs');
-// Timezone
-var utc = require('dayjs/plugin/utc');
-var timezone = require('dayjs/plugin/timezone');
-dayjs.extend(utc);
-dayjs.extend(timezone);
-
-function filterByOpenNow(locations) {
-  const tz = 'America/New_York';
-  const today = new Date();
-
-  // Get the current time, in format 13:56
-  // Force timezone to new york.
-  const nowTime = today.toLocaleTimeString('en-US', {
-    timeZone: 'America/New_York',
-    hour12: false,
-    hour: '2-digit',
-    minute:'2-digit'
-  });
-  // Get the current day in format: Thu
-  // Force timezone to new york.
-  const weekday = today.toLocaleDateString('en-US', {
-    timeZone: 'America/New_York',
-    weekday: 'short'
-  });
-
-  // Dayjs version
-  /*const timeZone = 'America/New_York';
-  let now = dayjs().tz(timeZone);
-  const todayJS = now.format('HH:mm');
-  console.log(todayJS);
-  */
-
-  const timeZone = 'America/New_York';
-  let now = dayjs().tz(timeZone);
-  const todayIso8601 = now.format();
+/**
+ * Takes an array of locations and reduces the array to only open now Locations.
+ *
+ * @param {object} now - current date object, unformatted.
+ * @param {array} locations - an array of Locations
+ * @return {array} a reduced array of locations that are open now.
+ */
+function filterByOpenNow(now, locations) {
+  // Format the now date object in the various formats we need.
+  const nowTime = now.format('HH:mm');
+  const weekday = now.format('ddd');
+  const today = now.format();
 
   return locations.reduce((accumlator, location) => {
     // Alerts
-    const alertsOpenStatus = checkAlertsOpenStatus(todayIso8601, location);
+    const alertsOpenStatus = checkAlertsOpenStatus(today, location._embedded.alerts);
 
     location.hours.regular.map(hoursItem => {
       // Find today in weekly hours.

--- a/src/utils/filterByOpenNow.js
+++ b/src/utils/filterByOpenNow.js
@@ -1,5 +1,13 @@
 import checkAlertsOpenStatus from './checkAlertsOpenStatus';
 
+// Dayjs
+const dayjs = require('dayjs');
+// Timezone
+var utc = require('dayjs/plugin/utc');
+var timezone = require('dayjs/plugin/timezone');
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
 function filterByOpenNow(locations) {
   const tz = 'America/New_York';
   const today = new Date();
@@ -19,9 +27,20 @@ function filterByOpenNow(locations) {
     weekday: 'short'
   });
 
+  // Dayjs version
+  /*const timeZone = 'America/New_York';
+  let now = dayjs().tz(timeZone);
+  const todayJS = now.format('HH:mm');
+  console.log(todayJS);
+  */
+
+  const timeZone = 'America/New_York';
+  let now = dayjs().tz(timeZone);
+  const todayIso8601 = now.format();
+
   return locations.reduce((accumlator, location) => {
     // Alerts
-    const alertsOpenStatus = checkAlertsOpenStatus(location);
+    const alertsOpenStatus = checkAlertsOpenStatus(todayIso8601, location);
 
     location.hours.regular.map(hoursItem => {
       // Find today in weekly hours.


### PR DESCRIPTION
[Jira Ticket](http://jira.nypl.org/browse/RENO-1830)

**This PR does the following:**
- Accommodate hours and mins in closing logic related to alerts/closings for all day closings.
- Removed `date-fns` and `date-fns-tz` packages.
- Adds `DayJS` package for handling and comparing dates.
- Refactors `checkAlertsOpenStatus()` util function to be testable and use `DayJS` for date comparisons.
- Adds unit tests for `checkAlertsOpenStatus()` util function

### Review Steps:
- [x] Pull in latest code, run npm install
- [x] Review unit tests in `checkAlertsOpenStatus.test.js` to see if they account for various data scenarios for testing.
- [x] Run tests locally, using `npm test` -- all tests should pass.
- [x] Review frontend of the app (there should be no noticeable frontend change, either in appearance or functionality).

