### PR TITLE
RENO-1937: Upgrade/Migrate to Apollo Client v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,70 @@
         "cross-fetch": "3.0.5"
       }
     },
+    "@apollo/client": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.3.3.tgz",
+      "integrity": "sha512-zs148iUbBgmeQFOc+Jc4/Cb3LK7urQuCQGHifviMp0ihxzbJ8rtj0hCVuQhWaZxZRcL5oZBCfIuL1O5xuvszmQ==",
+      "requires": {
+        "@graphql-typed-document-node/core": "^3.0.0",
+        "@types/zen-observable": "^0.8.0",
+        "@wry/context": "^0.5.2",
+        "@wry/equality": "^0.3.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graphql-tag": "^2.11.0",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.13.1",
+        "prop-types": "^15.7.2",
+        "symbol-observable": "^2.0.0",
+        "ts-invariant": "^0.5.1",
+        "tslib": "^1.10.0",
+        "zen-observable": "^0.8.14"
+      },
+      "dependencies": {
+        "@wry/context": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.5.2.tgz",
+          "integrity": "sha512-B/JLuRZ/vbEKHRUiGj6xiMojST1kHhu4WcreLfNN7q9DqQFrb97cWgf/kiYsPSUCAMVN0HzfFc8XjJdzgZzfjw==",
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        },
+        "@wry/equality": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.3.0.tgz",
+          "integrity": "sha512-DRDAu/e3oWBj826OWNV/GCmSdHD248mASXImgNoLE/3SDvpgb+k6G/+TAmdpIB35ju264+kB22Rx92eXg52DnA==",
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        },
+        "graphql-tag": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.11.0.tgz",
+          "integrity": "sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA=="
+        },
+        "optimism": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.13.1.tgz",
+          "integrity": "sha512-16RRVYZe8ODcUqpabpY7Gb91vCAbdhn8FHjlUb2Hqnjjow1j8Z1dlppds+yAsLbreNTVylLC+tNX6DuC2vt3Kw==",
+          "requires": {
+            "@wry/context": "^0.5.2"
+          }
+        },
+        "symbol-observable": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-2.0.3.tgz",
+          "integrity": "sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA=="
+        },
+        "ts-invariant": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.5.1.tgz",
+          "integrity": "sha512-k3UpDNrBZpqJFnAAkAHNmSHtNuCxcU6xLiziPgalHRKZHme6T6jnKC8CcXDmk1zbHLQM8pc+rNC1Q6FvXMAl+g==",
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        }
+      }
+    },
     "@apollo/protobufjs": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.0.4.tgz",
@@ -91,27 +155,6 @@
       "integrity": "sha512-X5Kyro73bthWSCBJUC5XYQqMnG0dLWuDZmVkzog9dynovhfiVCV4kPSdgSIkqnb++cwCzOVuQ4rDKVwo2XRzQA==",
       "requires": {
         "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
-      }
-    },
-    "@apollo/react-hooks": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@apollo/react-hooks/-/react-hooks-3.1.5.tgz",
-      "integrity": "sha512-y0CJ393DLxIIkksRup4nt+vSjxalbZBXnnXxYbviq/woj+zKa431zy0yT4LqyRKpFy9ahMIwxBnBwfwIoupqLQ==",
-      "requires": {
-        "@apollo/react-common": "^3.1.4",
-        "@wry/equality": "^0.1.9",
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
-      }
-    },
-    "@apollo/react-ssr": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@apollo/react-ssr/-/react-ssr-3.1.5.tgz",
-      "integrity": "sha512-wuLPkKlctNn3u8EU8rlECyktpOUCeekFfb0KhIKknpGY6Lza2Qu0bThx7D9MIbVEzhKadNNrzLcpk0Y8/5UuWg==",
-      "requires": {
-        "@apollo/react-common": "^3.1.4",
-        "@apollo/react-hooks": "^3.1.5",
         "tslib": "^1.10.0"
       }
     },
@@ -1549,6 +1592,11 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
+    },
+    "@graphql-typed-document-node/core": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.0.tgz",
+      "integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg=="
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -3091,9 +3139,9 @@
       "dev": true
     },
     "@types/zen-observable": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.0.tgz",
-      "integrity": "sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg=="
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.1.tgz",
+      "integrity": "sha512-wmk0xQI6Yy7Fs/il4EpOcflG4uonUpYGqvZARESLc2oy4u69fkatFLbJOeW4Q6awO15P4rduAe6xkwHevpXcUQ=="
     },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
@@ -3250,15 +3298,6 @@
         "@webassemblyjs/ast": "1.9.0",
         "@webassemblyjs/wast-parser": "1.9.0",
         "@xtuc/long": "4.2.2"
-      }
-    },
-    "@wry/context": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.4.4.tgz",
-      "integrity": "sha512-LrKVLove/zw6h2Md/KZyWxIkFM6AoyKp71OqpH9Hiip1csjPVoD3tPxlbQUNxEnHENks3UGgNpSBCAfq9KWuag==",
-      "requires": {
-        "@types/node": ">=6",
-        "tslib": "^1.9.3"
       }
     },
     "@wry/equality": {
@@ -3486,15 +3525,6 @@
         }
       }
     },
-    "apollo-cache": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.3.5.tgz",
-      "integrity": "sha512-1XoDy8kJnyWY/i/+gLTEbYLnoiVtS8y7ikBr/IfmML4Qb+CM7dEEbIUOjnY716WqmZ/UpXIxTfJsY7rMcqiCXA==",
-      "requires": {
-        "apollo-utilities": "^1.3.4",
-        "tslib": "^1.10.0"
-      }
-    },
     "apollo-cache-control": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.11.1.tgz",
@@ -3502,33 +3532,6 @@
       "requires": {
         "apollo-server-env": "^2.4.5",
         "apollo-server-plugin-base": "^0.9.1"
-      }
-    },
-    "apollo-cache-inmemory": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.6.tgz",
-      "integrity": "sha512-L8pToTW/+Xru2FFAhkZ1OA9q4V4nuvfoPecBM34DecAugUZEBhI2Hmpgnzq2hTKZ60LAMrlqiASm0aqAY6F8/A==",
-      "requires": {
-        "apollo-cache": "^1.3.5",
-        "apollo-utilities": "^1.3.4",
-        "optimism": "^0.10.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0"
-      }
-    },
-    "apollo-client": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.6.10.tgz",
-      "integrity": "sha512-jiPlMTN6/5CjZpJOkGeUV0mb4zxx33uXWdj/xQCfAMkuNAC3HN7CvYDyMHHEzmcQ5GV12LszWoQ/VlxET24CtA==",
-      "requires": {
-        "@types/zen-observable": "^0.8.0",
-        "apollo-cache": "1.3.5",
-        "apollo-link": "^1.0.0",
-        "apollo-utilities": "1.3.4",
-        "symbol-observable": "^1.0.2",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0",
-        "zen-observable": "^0.8.0"
       }
     },
     "apollo-datasource": {
@@ -3605,26 +3608,6 @@
         "ts-invariant": "^0.4.0",
         "tslib": "^1.9.3",
         "zen-observable-ts": "^0.8.21"
-      }
-    },
-    "apollo-link-http": {
-      "version": "1.5.17",
-      "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.17.tgz",
-      "integrity": "sha512-uWcqAotbwDEU/9+Dm9e1/clO7hTB2kQ/94JYcGouBVLjoKmTeJTUPQKcJGpPwUjZcSqgYicbFqQSoJIW0yrFvg==",
-      "requires": {
-        "apollo-link": "^1.2.14",
-        "apollo-link-http-common": "^0.2.16",
-        "tslib": "^1.9.3"
-      }
-    },
-    "apollo-link-http-common": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.16.tgz",
-      "integrity": "sha512-2tIhOIrnaF4UbQHf7kjeQA/EmSorB7+HyJIIrUjJOKBgnXwuexi8aMecRlqTIDWcyVXCeqLhUnztMa6bOH/jTg==",
-      "requires": {
-        "apollo-link": "^1.2.14",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3"
       }
     },
     "apollo-server-caching": {
@@ -10110,14 +10093,6 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
-      }
-    },
-    "optimism": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.10.3.tgz",
-      "integrity": "sha512-9A5pqGoQk49H6Vhjb9kPgAeeECfUDF6aIICbMDL23kDLStBn1MWk3YvcZ4xWF9CsSf6XEgvRLkXy4xof/56vVw==",
-      "requires": {
-        "@wry/context": "^0.4.0"
       }
     },
     "optionator": {

--- a/package.json
+++ b/package.json
@@ -10,16 +10,12 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
+    "@apollo/client": "^3.3.3",
     "@apollo/react-common": "^3.1.4",
-    "@apollo/react-hooks": "^3.1.5",
-    "@apollo/react-ssr": "^3.1.5",
     "@nypl/design-system-react-components": "^0.14.0",
     "@nypl/dgx-header-component": "git+https://git@github.com/NYPL/dgx-header-component.git#reactupdate",
     "@nypl/dgx-react-footer": "^0.5.7",
-    "apollo-cache-inmemory": "^1.6.6",
-    "apollo-client": "^2.6.10",
     "apollo-datasource-rest": "^0.9.3",
-    "apollo-link-http": "^1.5.17",
     "apollo-server-micro": "^2.16.1",
     "apollo-utilities": "^1.3.2",
     "breakpoint-sass": "2.7.0",

--- a/src/apollo/client/withApollo.js
+++ b/src/apollo/client/withApollo.js
@@ -1,8 +1,6 @@
 import Head from 'next/head';
-import { ApolloProvider } from '@apollo/react-hooks';
-import { ApolloClient } from 'apollo-client';
-import { InMemoryCache } from 'apollo-cache-inmemory';
-import { HttpLink } from 'apollo-link-http';
+import { ApolloClient, ApolloProvider, HttpLink } from '@apollo/client';
+import { InMemoryCache } from '@apollo/client/cache';
 const { NEXT_PUBLIC_GRAPHQL_API } = process.env;
 
 let globalApolloClient = null;
@@ -63,7 +61,7 @@ export function withApollo(PageComponent, { ssr = true } = {}) {
         if (ssr) {
           try {
             // Run all GraphQL queries
-            const { getDataFromTree } = await import('@apollo/react-ssr')
+            const { getDataFromTree } = await import('@apollo/client/react/ssr')
             await getDataFromTree(
               <AppTree
                 pageProps={{

--- a/src/components/location-finder/Locations/Locations.js
+++ b/src/components/location-finder/Locations/Locations.js
@@ -60,16 +60,13 @@ function Locations() {
         limit,
         offset,
         pageNumber
-      },
-      fetchPolicy: "cache-and-network",
-      notifyOnNetworkStatusChange: true
+      }
     }
   );
 
   // Side effect to dispatch redux action to set pagination redux state.
   useEffect(() => {
     if (data) {
-      console.log('useEffect!');
       // Dispatch redux action
       dispatch(setPagination({
         pageNumber: pageNumber,

--- a/src/components/location-finder/Locations/Locations.js
+++ b/src/components/location-finder/Locations/Locations.js
@@ -1,7 +1,7 @@
 import React, { Fragment, useEffect, useState } from 'react';
 // Apollo
 import gql from 'graphql-tag';
-import { useQuery } from '@apollo/react-hooks';
+import { useQuery } from '@apollo/client';
 import { LocationsQuery as LOCATIONS_QUERY } from './Locations.gql';
 // Map
 import Map from './../Map';
@@ -69,6 +69,7 @@ function Locations() {
   // Side effect to dispatch redux action to set pagination redux state.
   useEffect(() => {
     if (data) {
+      console.log('useEffect!');
       // Dispatch redux action
       dispatch(setPagination({
         pageNumber: pageNumber,

--- a/src/components/location-finder/Locations/LocationsPagination.js
+++ b/src/components/location-finder/Locations/LocationsPagination.js
@@ -114,21 +114,22 @@ function LocationsPagination({ limit }) {
         >
           Page{' '}
         </DS.Label>
-        <DS.Select
-          ariaLabel="Pagination Label"
-          id="paginationSelect"
-          labelId="paginationLabel"
+        <select
           name="Pagination Select"
+          aria-label="Pagination Label"
+          id="paginationSelect"
+          className="select"
+          aria-labelledby="paginationLabel"
           onBlur={onPageChange}
           onChange={onPageChange}
-          selectedOption={`${pageNumber} of ${pageCount}`}
+          value={`${pageNumber} of ${pageCount}`}
         >
           {paginationDropdownOptions.map((option) => (
             <option>
               {option}
             </option>
           ))}
-        </DS.Select>
+        </select>
       </DS.Pagination>
     );
   } else {

--- a/src/components/location-finder/Map/index.js
+++ b/src/components/location-finder/Map/index.js
@@ -8,7 +8,7 @@ const { NEXT_PUBLIC_GOOGLE_MAPS_API } = process.env;
 import { useDispatch, useSelector } from 'react-redux';
 import { setMapInfoWindow } from './../../../redux/actions';
 // Apollo
-import { useQuery } from '@apollo/react-hooks';
+import { useQuery } from '@apollo/client';
 import { LocationsQuery as LOCATIONS_QUERY } from './Locations.gql';
 // Hooks
 import useWindowSize from './../../../hooks/useWindowSize';

--- a/src/components/location-finder/SearchAutoSuggest/SearchAutoSuggest.js
+++ b/src/components/location-finder/SearchAutoSuggest/SearchAutoSuggest.js
@@ -1,6 +1,6 @@
 import React, { Fragment, useState } from 'react';
 // Apollo
-import { useLazyQuery } from '@apollo/react-hooks';
+import { useLazyQuery } from '@apollo/client';
 import { LocationsQuery as LOCATIONS_QUERY } from './SearchAutoSuggest.gql';
 // Redux
 import {

--- a/src/components/location-finder/SearchForm/SearchForm.js
+++ b/src/components/location-finder/SearchForm/SearchForm.js
@@ -13,7 +13,7 @@ import {
   setPagination
 } from './../../../redux/actions';
 // Apollo
-import { useApolloClient } from '@apollo/react-hooks';
+import { useApolloClient } from '@apollo/client';
 import { LocationsQuery as LOCATIONS_QUERY } from './SearchForm.gql';
 // Utils
 import filterBySearchInput from './../../../utils/filterBySearchInput';

--- a/src/pages/locations/index.js
+++ b/src/pages/locations/index.js
@@ -1,4 +1,4 @@
-import { getDataFromTree } from '@apollo/react-ssr';
+import { getDataFromTree } from '@apollo/client/react/ssr';
 import { withApollo } from './../../apollo/client/withApollo';
 // Redux
 import { withRedux } from './../../redux/withRedux';


### PR DESCRIPTION
[Jira Ticket](http://jira.nypl.org/browse/RENO-1937)

**This PR does the following:**
- Upgrades to Apollo Client 3 (now uses @apollo/client) (Read more here: https://www.apollographql.com/docs/react/migrating/apollo-client-3-migration/)
- Removes the following modules not needed with `@apollo/client`
  - @apollo/react-hooks
  - @apollo/react-ssr
  - apollo-cache-inmemory
  - apollo-client
  - apollo-link-http
- Fixed duplicate render issue caused by apollo client 3.

### Review Steps:
- [ ] Pull in branch
- [ ] Run npm install
- [ ] Run npm run dev
- [ ] Test basic app functionality (app should work the same as production)
