### PR TITLE
RENO-1951 - fix SNFL/Business Center console error

### DIFF
--- a/src/components/location-finder/Location/Location.js
+++ b/src/components/location-finder/Location/Location.js
@@ -46,7 +46,7 @@ function Location({ location }) {
   return (
     <div className='location'>
       <DS.Heading
-        id={ `lid-${location.id}` }
+        id={ `lid-${location.id.replace('/', '-')}` }
         level={2}
         className='location__name'
       >

--- a/src/components/location-finder/Map/index.js
+++ b/src/components/location-finder/Map/index.js
@@ -123,9 +123,9 @@ function Map() {
     // Scroll to location on list when map marker is clicked for desktop only.
     if (windowSize >= 600) {
       // Set focus
-      document.querySelector(`#lid-${location.id} a`).focus();
+      document.querySelector(`#lid-${location.id.replace('/', '-')} a`).focus();
       // Scroll into view.
-      document.getElementById(`lid-${location.id}`).scrollIntoView({
+      document.getElementById(`lid-${location.id.replace('/', '-')}`).scrollIntoView({
         alignToTop: false,
         behavior: 'smooth'
       });


### PR DESCRIPTION
[Jira Ticket](http://jira.nypl.org/browse/RENO-1951)

**This PR does the following:**
- Fixes a console error due to the SNFL/Business Center location id "snfl/business" having a forward slash.  Issue is fixed by replacing the forward slash with a dash "-".

### Review Steps:
- [ ] Pull in latest code
- [ ] Review example

### Front End Review Steps:
- [ ] View [Example](http://localhost:3000/)
