### PR TITLE
Set timezone for docker container to america/new_york

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ WORKDIR /app
 
 ENV PATH /app/node_modules/.bin:$PATH
 
+# Set the timezone
+ENV TZ=America/New_York
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
 # Install dependencies.
 COPY package.json ./
 RUN npm install


### PR DESCRIPTION
[Jira Ticket](http://jira.nypl.org/browse/RENO-2110)

**This PR does the following:**
- Sets the timezone for Docker container/server.

### Review Steps:
- [ ] Example step one
