### PR TITLE
RENO-2108: Wire Up Division By Appointment Only Field

### DIFF
--- a/src/apollo/server/resolvers/locationResolver.js
+++ b/src/apollo/server/resolvers/locationResolver.js
@@ -180,7 +180,7 @@ const locationResolver = {
       );
     },
     appointmentOnly: location => {
-      if (location.by_appointment_only && location.by_appointment_only !== 'null') {
+      if (location.by_appointment_only) {
         return true;
       } else {
         return false;

--- a/src/apollo/server/resolvers/locationResolver.js
+++ b/src/apollo/server/resolvers/locationResolver.js
@@ -179,6 +179,13 @@ const locationResolver = {
         hasActiveClosing(today, location._embedded.alerts, null) && !location.open
       );
     },
+    appointmentOnly: location => {
+      if (location.by_appointment_only && location.by_appointment_only !== 'null') {
+        return true;
+      } else {
+        return false;
+      }
+    },
     open: location => {
       // Create a dayjs date object, using default timezone.
       // @see https://github.com/iamkun/dayjs/issues/1227

--- a/src/apollo/server/type-defs.js
+++ b/src/apollo/server/type-defs.js
@@ -18,6 +18,7 @@ export const typeDefs = gql`
     accessibilityNote: String
     geoLocation: GeoLocation
     todayHours: TodayHours
+    appointmentOnly: Boolean
     open: Boolean
     terms: [String]
   }

--- a/src/components/location-finder/Location/Location.js
+++ b/src/components/location-finder/Location/Location.js
@@ -65,6 +65,7 @@ function Location({ location }) {
         open={location.open}
         todayHoursStart={location.todayHours.start}
         todayHoursEnd={location.todayHours.end}
+        appointmentOnly={location.appointmentOnly}
       />
       <LocationDistance locationPoint={location.geoLocation} />
       <div className='location__links'>

--- a/src/components/location-finder/Location/Location.scss
+++ b/src/components/location-finder/Location/Location.scss
@@ -55,6 +55,12 @@
     }
   }
 
+  .location__hours-appointment {
+    padding-left: $space-m;
+    margin: -5px 0 5px 0;
+    font-weight: 700;
+  }
+
   .location__distance {
     @include space-stack-xxs;
   }

--- a/src/components/location-finder/Location/LocationHours.js
+++ b/src/components/location-finder/Location/LocationHours.js
@@ -22,16 +22,9 @@ function LocationHours({ open, todayHoursStart, todayHoursEnd, appointmentOnly }
     const endMeridiem = (endHoursOnly < 12 || endHoursOnly === 24) ? "AM" : "PM";
     const endMinutesOnly = end.substr(3, 2);
     const endHoursFinal = (endMinutesOnly != 0) ? (endHours + ':' + endMinutesOnly) : endHours;
-    
-    let formattedHours;
-    formattedHours = `${startHoursFinal}${startMeridiem}–${endHoursFinal}${endMeridiem}`;
-    
-    // Append asterisk for by appointment only.
-    if (appointment) {
-      formattedHours = `${formattedHours}*`
-    }
 
-    return formattedHours;
+    // Append asterisk if location hours are by appointment only.
+    return `${startHoursFinal}${startMeridiem}–${endHoursFinal}${endMeridiem}${appointment ? `*` : ``}`;
   }
 
   return (

--- a/src/components/location-finder/Location/LocationHours.js
+++ b/src/components/location-finder/Location/LocationHours.js
@@ -1,9 +1,9 @@
 import React, { Fragment } from 'react';
 import { Icon, StatusBadge } from '@nypl/design-system-react-components';
 
-function LocationHours({ open, todayHoursStart, todayHoursEnd }) {
+function LocationHours({ open, todayHoursStart, todayHoursEnd, appointmentOnly }) {
   // Convert hours to 12 hour time format
-  function formatHours(start, end) {
+  function formatHours(start, end, appointment) {
     // Sometimes refinery will return null for start and end times.
     if (start === null || end === null) {
       return 'Closed';
@@ -22,8 +22,16 @@ function LocationHours({ open, todayHoursStart, todayHoursEnd }) {
     const endMeridiem = (endHoursOnly < 12 || endHoursOnly === 24) ? "AM" : "PM";
     const endMinutesOnly = end.substr(3, 2);
     const endHoursFinal = (endMinutesOnly != 0) ? (endHours + ':' + endMinutesOnly) : endHours;
+    
+    let formattedHours;
+    formattedHours = `${startHoursFinal}${startMeridiem}–${endHoursFinal}${endMeridiem}`;
+    
+    // Append asterisk for by appointment only.
+    if (appointment) {
+      formattedHours = `${formattedHours}*`
+    }
 
-    return `${startHoursFinal}${startMeridiem}–${endHoursFinal}${endMeridiem}`;
+    return formattedHours;
   }
 
   return (
@@ -36,16 +44,21 @@ function LocationHours({ open, todayHoursStart, todayHoursEnd }) {
           />
           Today's Hours:
           <div className='location__hours-hours'>
-            {formatHours(todayHoursStart, todayHoursEnd)}
+            {formatHours(todayHoursStart, todayHoursEnd, appointmentOnly)}
           </div>
         </div>
       ) : (
-          <StatusBadge 
-            level={"medium"} 
-            statusBadgeText={"Location is temporarily closed"}
-            className={'location__hours-status'}
-          />
-        )}
+        <StatusBadge 
+          level={"medium"} 
+          statusBadgeText={"Location is temporarily closed"}
+          className={'location__hours-status'}
+        />
+      )}
+      {appointmentOnly && todayHoursStart && todayHoursEnd &&
+        <div className='location__hours-appointment'>
+          * Division is by appointment only.
+        </div>
+      }
     </Fragment>
   );
 }

--- a/src/components/location-finder/Location/LocationHours.test.js
+++ b/src/components/location-finder/Location/LocationHours.test.js
@@ -120,6 +120,36 @@ describe('LocationHours Component', () => {
     expect(screen.getByText('Closed')).toBeInTheDocument();
   });
 
+  test('Location with regular hours and by appointment only should render hours notice.', () => {
+    render(
+      <LocationHours
+        open={true}
+        todayHoursStart={'11:15'}
+        todayHoursEnd={'14:01'}
+        appointmentOnly={true}
+      />
+    );
+
+    expect(screen.getByText('* Division is by appointment only.')).toBeInTheDocument();
+    expect(screen.getByText("Today's Hours:")).toBeInTheDocument();
+    expect(screen.getByText('11:15AM–2:01PM*')).toBeInTheDocument();
+  });
+
+  test('Location with regular hours, but not by appointment only should not render hours notice.', () => {
+    render(
+      <LocationHours
+        open={true}
+        todayHoursStart={'11:15'}
+        todayHoursEnd={'14:00'}
+        appointmentOnly={false}
+      />
+    );
+
+    expect(screen.queryByText('* Division is by appointment only.')).not.toBeInTheDocument();
+    expect(screen.getByText("Today's Hours:")).toBeInTheDocument();
+    expect(screen.getByText('11:15AM–2PM')).toBeInTheDocument();
+  });
+
   // Accessbiility tests.
   it('should not have basic accessibility issues', async () => {
     const { container } = render(

--- a/src/components/location-finder/Locations/Locations.gql
+++ b/src/components/location-finder/Locations/Locations.gql
@@ -42,6 +42,7 @@ query LocationsQuery(
         start
         end
       }
+      appointmentOnly
       open
     }
     pageInfo {

--- a/testHelper/__mocks/allLocations.js
+++ b/testHelper/__mocks/allLocations.js
@@ -21,6 +21,7 @@ const allLocations = {
             start: '11:00',
             end: '18:00'
           },
+          appointmentOnly: false,
           open: true,
           geoLocation: {
             lat: 40.8034,
@@ -47,6 +48,7 @@ const allLocations = {
             start: '11:00',
             end: '19:00'
           },
+          appointmentOnly: false,
           open: true,
           geoLocation: {
             lat: 40.7608,


### PR DESCRIPTION
[Jira Ticket](http://jira.nypl.org/browse/RENO-2108)

**This PR does the following:**
- Adds "by appointment only" notice message for Divisions that have by appointment only hours. Currently, only "DeWitt Wallace Periodical Room" has this data, and related notice.

### Review Steps:
- [ ] Review the preview environment. Only "DeWitt Wallace Periodical Room" has this data, so it should have a notice that says "Division hours are by appointment only".

### Front End Review Steps:
- [ ] View [Preview Env](https://pr114-temsuyxqw1mt8p8czi2dj2sgtf2fy24l.tugboat.qa/locations)
