### PR TITLE
RENO-2115: Adds Selected Items Count to Mobile Filters Button

### DIFF
--- a/src/components/location-finder/SearchFilters/FiltersButton.js
+++ b/src/components/location-finder/SearchFilters/FiltersButton.js
@@ -30,14 +30,37 @@ function FiltersButton(props) {
     setIsModalOpen(true);
   }
 
+  function setFiltersLabel(searchFilters) {    
+    let allItems = [];
+    for (let [key, value] of Object.entries(searchFilters)) {
+      value.terms.map(term => {
+        allItems.push(term);
+      })
+    }
+    return `Filters ${allItems.length ? `(${allItems.length})` : ``}`;
+  }
+
+  function hasSelectedItems(searchFilters) {
+    if (Object.keys(searchFilters).length > 0) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
   return (
-    <Button 
-      id='search-filters__mobile-filters-button' 
-      onClick={() => onClick()}
-      buttonType='outline'
+    <div className={hasSelectedItems(searchFilters)
+      ? `mobile-filters-button hasSelectedItems` 
+      : `mobile-filters-button`}
     >
-      Filters
-    </Button>
+      <Button 
+        id='search-filters__mobile-filters-button' 
+        onClick={() => onClick()}
+        buttonType='outline'
+      >
+        {setFiltersLabel(searchFilters)}
+      </Button>
+    </div>
   );
 }
 

--- a/src/components/location-finder/SearchFilters/SearchFilters.scss
+++ b/src/components/location-finder/SearchFilters/SearchFilters.scss
@@ -65,6 +65,11 @@
       min-width: 140px;
     }
 
+    .mobile-filters-button.hasSelectedItems button {
+      background: $gray-light;
+      border: 1px solid $black;
+    }
+
     .dropdown-mobile-clear-wrapper button {
       margin: 0 auto;
     }


### PR DESCRIPTION
[Jira Ticket](http://jira.nypl.org/browse/RENO-2115)

**This PR does the following:**
- For mobile only, Filters button now has a count of the number of selected items.

### Review Steps:
- [ ] Go to preview env on mobile, open filters, and select several items. There should now be a count of the selected items on the Filters button, i.e., "Filters (3)"

### Front End Review Steps:
- [ ] View [Preview Enviornment](https://pr118-wqm4apvwnkkbxshasb2nrcuudiyz90vl.tugboat.qa/locations)
