### PR TITLE
RENO-2120: Improvements for Sort By Distance to Include Location Name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10453,6 +10453,25 @@
       "resolved": "https://registry.npmjs.org/markerwithlabel/-/markerwithlabel-2.0.2.tgz",
       "integrity": "sha512-C/cbm1A0h/u54gwHk5ZJNdUU3V3+1BbCpRPMsMyFA7vF4yL+aB4rWpxACz29TpQ+cTg6/iQroExh0PMSRGtQFg=="
     },
+    "match-sorter": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.0.tgz",
+      "integrity": "sha512-efYOf/wUpNb8FgNY+cOD2EIJI1S5I7YPKsw0LBp7wqPh5pmMS6i/wr3ZWwfwrAw1NvqTA2KUReVRWDX84lUcOQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "remove-accents": "0.4.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -12263,6 +12282,11 @@
           }
         }
       }
+    },
+    "remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U="
     },
     "remove-trailing-separator": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "graphql-tag": "2.10.3",
     "graphql-tools": "^7.0.2",
     "lodash.isequal": "^4.5.0",
+    "match-sorter": "^6.3.0",
     "micro-cors": "^0.1.1",
     "next": "9.5.5",
     "prop-types": "^15.6.2",

--- a/src/apollo/client/queries/Locations.gql
+++ b/src/apollo/client/queries/Locations.gql
@@ -1,6 +1,7 @@
 query LocationsQuery(
   $searchGeoLat: Float,
   $searchGeoLng: Float,
+  $searchQuery: String,
   $openNow: Boolean,
   $termIds: [TermsFilter],
   $limit: Int,
@@ -17,7 +18,8 @@ query LocationsQuery(
     },
     sortByDistance: {
       originLat: $searchGeoLat,
-      originLng: $searchGeoLng
+      originLng: $searchGeoLng,
+      searchQuery: $searchQuery
     }
   ) {
     locations {

--- a/src/apollo/server/resolvers/locationResolver.js
+++ b/src/apollo/server/resolvers/locationResolver.js
@@ -70,6 +70,8 @@ const locationResolver = {
         && args.sortByDistance.originLat
         && args.sortByDistance.originLng
       ) {
+        console.log('sort by dist!')
+        
         if (typeof results !== "undefined") {
           results = sortByDistance(args.sortByDistance, results);
         } else {

--- a/src/apollo/server/resolvers/locationResolver.js
+++ b/src/apollo/server/resolvers/locationResolver.js
@@ -69,11 +69,7 @@ const locationResolver = {
         && 'originLng' in args.sortByDistance
         && args.sortByDistance.originLat
         && args.sortByDistance.originLng
-      ) {
-        console.log('sort by dist!')
-
-        console.log(args.sortByDistance.searchQuery);
-        
+      ) {        
         if (typeof results !== "undefined") {
           results = sortByDistance(args.sortByDistance, results, args.sortByDistance.searchQuery);
         } else {

--- a/src/apollo/server/resolvers/locationResolver.js
+++ b/src/apollo/server/resolvers/locationResolver.js
@@ -71,11 +71,13 @@ const locationResolver = {
         && args.sortByDistance.originLng
       ) {
         console.log('sort by dist!')
+
+        console.log(args.sortByDistance.searchQuery);
         
         if (typeof results !== "undefined") {
-          results = sortByDistance(args.sortByDistance, results);
+          results = sortByDistance(args.sortByDistance, results, args.sortByDistance.searchQuery);
         } else {
-          results = sortByDistance(args.sortByDistance, allLocations);
+          results = sortByDistance(args.sortByDistance, allLocations, args.sortByDistance.searchQuery);
         }
       }
 

--- a/src/apollo/server/type-defs.js
+++ b/src/apollo/server/type-defs.js
@@ -37,6 +37,7 @@ export const typeDefs = gql`
   input SortByDistance {
     originLat: Float
     originLng: Float
+    searchQuery: String
   }
 
   input Filter {

--- a/src/components/location-finder/Locations/Locations.js
+++ b/src/components/location-finder/Locations/Locations.js
@@ -33,6 +33,7 @@ function Locations() {
   const {
     searchQueryGeoLat,
     searchQueryGeoLng,
+    searchQuery,
     openNow,
     searchFilters, 
     offset,
@@ -53,6 +54,7 @@ function Locations() {
       variables: {
         searchGeoLat,
         searchGeoLng,
+        searchQuery,
         openNow,
         termIds,
         limit,

--- a/src/components/location-finder/Locations/Locations.test.js
+++ b/src/components/location-finder/Locations/Locations.test.js
@@ -4,7 +4,10 @@ import { render } from './../../../../testHelper/customRtlRender';
 import '@testing-library/jest-dom/extend-expect';
 import { GraphQLError } from 'graphql';
 import Locations from './Locations';
-import { LocationsQuery as LOCATIONS_QUERY } from './Locations.gql';
+//import { LocationsQuery as LOCATIONS_QUERY } from './Locations.gql';
+import { 
+  LocationsQuery as LOCATIONS_QUERY 
+} from './../../../apollo/client/queries/Locations.gql';
 // Mock data
 import allLocations from './../../../../testHelper/__mocks/allLocations';
 // Hooks
@@ -20,6 +23,7 @@ const mocks = [
       variables: {
         searchGeoLat: null,
         searchGeoLng: null,
+        searchQuery: '',
         openNow: true,
         limit: 300,
         offset: 0,
@@ -70,6 +74,7 @@ describe('Apollo states test', () => {
           variables: {
             searchGeoLat: null,
             searchGeoLng: null,
+            searchQuery: '',
             openNow: true,
             limit: 300,
             offset: 0,
@@ -125,5 +130,4 @@ describe('Apollo states test', () => {
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
-
 });

--- a/src/components/location-finder/Map/Map.js
+++ b/src/components/location-finder/Map/Map.js
@@ -28,6 +28,7 @@ const MapWrapper = compose(withScriptjs, withGoogleMap)(props => {
   const {
     searchQueryGeoLat,
     searchQueryGeoLng,
+    searchQuery,
     openNow,
     offset,
     pageNumber,
@@ -59,6 +60,7 @@ const MapWrapper = compose(withScriptjs, withGoogleMap)(props => {
       variables: {
         searchGeoLat,
         searchGeoLng,
+        searchQuery,
         openNow,
         termIds,
         limit,

--- a/src/components/location-finder/SearchForm/SearchForm.js
+++ b/src/components/location-finder/SearchForm/SearchForm.js
@@ -62,6 +62,7 @@ function SearchForm() {
     client.query({ query: LOCATIONS_QUERY }).then(
       response => {
         let searchValue = autoSuggestInputValue;
+        // @TODO see if you actually still need this.
         // Try to find a location match.
         const matchLocation = filterBySearchInput(response.data.allLocations.locations, autoSuggestInputValue);
         if (matchLocation[0]) {

--- a/src/utils/sortByDistance.js
+++ b/src/utils/sortByDistance.js
@@ -36,6 +36,13 @@ function sortByDistance(origin, locations, searchQuery) {
   });
 }
 
+/**
+ * Compared two geocordinate pairs and determines distance.
+ *
+ * @param {object} aGeo - geocordinate pair a.
+ * @param {object} bGeo - geocordinate pair b.
+ * @return {float} Distance between 2 geocordinate points.
+ */
 function distance(aGeo, bGeo) {
   var radlat1 = Math.PI * aGeo['lat'] / 180;
   var radlat2 = Math.PI * bGeo['lat'] / 180;

--- a/src/utils/sortByDistance.js
+++ b/src/utils/sortByDistance.js
@@ -16,6 +16,8 @@ function sortByDistance(origin, locations) {
   console.log('originLat: ' + origin.originLat);
   console.log('originLng: ' + origin.originLng);
 
+  //console.log(locations);
+
   return locations.sort(function (a, b) {
     const origLat = origin.originLat;
     const origLng = origin.originLng;
@@ -24,6 +26,10 @@ function sortByDistance(origin, locations) {
     const aGeoLng = a.geolocation.coordinates[0];
     const bGeoLat = b.geolocation.coordinates[1];
     const bGeoLng = b.geolocation.coordinates[0];
+
+    if (aGeoLat === bGeoLat && aGeoLng === bGeoLng) {
+      //console.log(b.name)
+    }
 
     return distance(origLat, origLng, aGeoLat, aGeoLng) - distance(origLat, origLng, bGeoLat, bGeoLng);
   });

--- a/src/utils/sortByDistance.js
+++ b/src/utils/sortByDistance.js
@@ -1,11 +1,20 @@
+import { matchSorter } from 'match-sorter';
+
 /**
  * Sorts an array of locations by distance from an origin geocordinate pair.
  *
  * @param {object} origin - origin geocordinate pair.
  * @param {array} locations - array of location objects.
+ * @param {string} searchQuery - search query submitted by user.
  * @return {sort} Return array of location objects, sorted by distance.
  */
-function sortByDistance(origin, locations) {
+function sortByDistance(origin, locations, searchQuery) {
+  // Pre-sort the locations based on match of searchQuery.
+  locations = matchSorter(locations, searchQuery, {
+    keys: ['name'],
+    threshold: matchSorter.rankings.NO_MATCH
+  });
+
   return locations.sort((a, b) => {
     // Origin
     const originGeo = {

--- a/src/utils/sortByDistance.js
+++ b/src/utils/sortByDistance.js
@@ -1,7 +1,36 @@
-function distance(lat1, lon1, lat2, lon2) {
-  var radlat1 = Math.PI * lat1 / 180;
-  var radlat2 = Math.PI * lat2 / 180;
-  var theta = lon1 - lon2;
+/**
+ * Sorts an array of locations by distance from an origin geocordinate pair.
+ *
+ * @param {object} origin - origin geocordinate pair.
+ * @param {array} locations - array of location objects.
+ * @return {sort} Return array of location objects, sorted by distance.
+ */
+function sortByDistance(origin, locations) {
+  return locations.sort((a, b) => {
+    // Origin
+    const originGeo = {
+      lat: origin.originLat,
+      lng: origin.originLng
+    };
+
+    const aGeo = {
+      lat: a.geolocation.coordinates[1],
+      lng: a.geolocation.coordinates[0]
+    };
+
+    const bGeo = {
+      lat: b.geolocation.coordinates[1],
+      lng: b.geolocation.coordinates[0]
+    }
+
+    return distance(originGeo, aGeo) - distance(originGeo, bGeo);
+  });
+}
+
+function distance(aGeo, bGeo) {
+  var radlat1 = Math.PI * aGeo['lat'] / 180;
+  var radlat2 = Math.PI * bGeo['lat'] / 180;
+  var theta = aGeo['lng'] - bGeo['lng'];
   var radtheta = Math.PI * theta / 180;
   var dist = Math.sin(radlat1) * Math.sin(radlat2) + Math.cos(radlat1) * Math.cos(radlat2) * Math.cos(radtheta);
   dist = Math.acos(dist);
@@ -11,28 +40,5 @@ function distance(lat1, lon1, lat2, lon2) {
 
   return dist;
 };
-
-function sortByDistance(origin, locations) {
-  console.log('originLat: ' + origin.originLat);
-  console.log('originLng: ' + origin.originLng);
-
-  //console.log(locations);
-
-  return locations.sort(function (a, b) {
-    const origLat = origin.originLat;
-    const origLng = origin.originLng;
-
-    const aGeoLat = a.geolocation.coordinates[1];
-    const aGeoLng = a.geolocation.coordinates[0];
-    const bGeoLat = b.geolocation.coordinates[1];
-    const bGeoLng = b.geolocation.coordinates[0];
-
-    if (aGeoLat === bGeoLat && aGeoLng === bGeoLng) {
-      //console.log(b.name)
-    }
-
-    return distance(origLat, origLng, aGeoLat, aGeoLng) - distance(origLat, origLng, bGeoLat, bGeoLng);
-  });
-}
 
 export default sortByDistance;

--- a/src/utils/sortByDistance.test.js
+++ b/src/utils/sortByDistance.test.js
@@ -1,0 +1,49 @@
+import sortByDistance from './sortByDistance';
+
+describe('sortByDistance', () => {
+  test('Search for SASB geocords should return SASB.', () => {
+    // SASB
+    const origin = {
+      'originLat': 40.7534887,
+      'originLng': -73.9808774
+    };
+
+    const locations = [
+      {
+        slug: "125th-street",
+        geolocation: {
+          type: "Point",
+          coordinates: [
+            -73.9354,
+            40.8034
+          ]
+        }
+      },
+      {
+        slug: "snfl",
+        geolocation: {
+          type: "Point",
+          coordinates: [
+            -73.9818,
+            40.752
+          ]
+        }
+      },
+      {
+        slug: "sasb",
+        geolocation: {
+          type: "Point",
+          coordinates: [
+            -73.9808774,
+            40.7534887
+          ]
+        }
+      }
+    ];
+
+    const result = sortByDistance(origin, locations);
+    expect(result[0].slug).toEqual('sasb');
+  });
+
+  
+});

--- a/src/utils/sortByDistance.test.js
+++ b/src/utils/sortByDistance.test.js
@@ -1,6 +1,44 @@
 import sortByDistance from './sortByDistance';
 
 describe('sortByDistance', () => {
+  //beforeEach(() => jest.clearAllMocks());
+
+  const locations = [
+    {
+      name: "125th Street Library",
+      slug: "125th-street",
+      geolocation: {
+        type: "Point",
+        coordinates: [
+          -73.9350089,
+          40.8030055
+        ]
+      }
+    },
+    {
+      name: "Stavros Niarchos Foundation Library",
+      slug: "snfl",
+      geolocation: {
+        type: "Point",
+        coordinates: [
+          -73.98170549999999,
+          40.8030055
+        ]
+      }
+    },
+    {
+      name: "Stephen A. Schwarzman Building",
+      slug: "sasb",
+      geolocation: {
+        type: "Point",
+        coordinates: [
+          -73.9808774,
+          40.7534887
+        ]
+      }
+    }
+  ];
+
   test('Search for SASB geocords should return SASB.', () => {
     // SASB
     const origin = {
@@ -8,42 +46,18 @@ describe('sortByDistance', () => {
       'originLng': -73.9808774
     };
 
-    const locations = [
-      {
-        slug: "125th-street",
-        geolocation: {
-          type: "Point",
-          coordinates: [
-            -73.9354,
-            40.8034
-          ]
-        }
-      },
-      {
-        slug: "snfl",
-        geolocation: {
-          type: "Point",
-          coordinates: [
-            -73.9818,
-            40.752
-          ]
-        }
-      },
-      {
-        slug: "sasb",
-        geolocation: {
-          type: "Point",
-          coordinates: [
-            -73.9808774,
-            40.7534887
-          ]
-        }
-      }
-    ];
-
-    const result = sortByDistance(origin, locations);
+    const result = sortByDistance(origin, locations, 'Stephen A. Schwarzman Building');
     expect(result[0].slug).toEqual('sasb');
   });
 
-  
+  test('Search for SNFL geocords should return SNFL.', () => {
+    // SNFL
+    const origin2 = {
+      'originLat': 40.7518863,
+      'originLng': -73.98170549999999
+    };
+
+    const result = sortByDistance(origin2, locations, 'Stavros Niarchos Foundation');
+    expect(result[0].slug).toEqual('snfl');
+  });
 });

--- a/src/utils/sortByDistance.test.js
+++ b/src/utils/sortByDistance.test.js
@@ -10,8 +10,8 @@ describe('sortByDistance', () => {
       geolocation: {
         type: "Point",
         coordinates: [
-          -73.9350089,
-          40.8030055
+          -73.9354,
+          40.8034
         ]
       }
     },
@@ -21,8 +21,8 @@ describe('sortByDistance', () => {
       geolocation: {
         type: "Point",
         coordinates: [
-          -73.98170549999999,
-          40.8030055
+          -73.9818,
+          40.752
         ]
       }
     },
@@ -36,10 +36,21 @@ describe('sortByDistance', () => {
           40.7534887
         ]
       }
+    },
+    {
+      name: "DeWitt Wallace Periodical Room",
+      slug: "periodicals-room",
+      geolocation: {
+        type: "Point",
+        coordinates: [
+          -73.9808774,
+          40.7534887
+        ]
+      }
     }
   ];
 
-  test('Search for SASB geocords should return SASB.', () => {
+  test('Search for SASB should return SASB first.', () => {
     // SASB
     const origin = {
       'originLat': 40.7534887,
@@ -50,14 +61,25 @@ describe('sortByDistance', () => {
     expect(result[0].slug).toEqual('sasb');
   });
 
-  test('Search for SNFL geocords should return SNFL.', () => {
+  test('Search for SNFL should return SNFL before SASB.', () => {
     // SNFL
-    const origin2 = {
+    const origin = {
       'originLat': 40.7518863,
       'originLng': -73.98170549999999
     };
 
-    const result = sortByDistance(origin2, locations, 'Stavros Niarchos Foundation');
+    const result = sortByDistance(origin, locations, 'Stavros Niarchos Foundation');
     expect(result[0].slug).toEqual('snfl');
+  });
+
+  test('Search for Dewitt should return Dewitt before SASB.', () => {
+    // Dewitt/SASB
+    const origin = {
+      'originLat': 40.7534887,
+      'originLng': -73.9808774
+    };
+
+    const result = sortByDistance(origin, locations, 'Dewitt');
+    expect(result[0].slug).toEqual('periodicals-room');
   });
 });


### PR DESCRIPTION
[Jira Ticket](http://jira.nypl.org/browse/RENO-2120)

**This PR does the following:**
- Since Divisions and Centers have the same address as their parent Locations, these locations were not appearing at the top of the search results list. This PR adds functionality to ensure that if someone searches for a division such as "Dewitt", for example, it will appear as the top result, over "SASB" (parent location).

### Review Steps:
- [ ] View Preview Env here: https://pr123-kl9zsb8qd6at9vykvd4xgcb5kxkucf5s.tugboat.qa/locations
- [ ] When I search DeWitt, it should be the first or second result. Only SASB should appear before it.
- [ ] When I search Rodgers, it should be the first or second result. Only LPA should appear before it.
- [ ] When I search Blackwell, it should be the first or second result. Only Schomburg should appear before it.
- [ ] When I search Yoseloff, it should be the first or second result. Only SNFL should appear before it.

### Front End Review Steps:
- [ ] View [Preview Env](https://pr123-kl9zsb8qd6at9vykvd4xgcb5kxkucf5s.tugboat.qa/locations)
