### PR TITLE
RENO-2309: Remove HYML Entities From Title Field + Render Description as HTML

### DIFF
--- a/src/apollo/server/resolvers/autoSuggestionsResolver.js
+++ b/src/apollo/server/resolvers/autoSuggestionsResolver.js
@@ -6,7 +6,7 @@ const autoSuggestionsResolver = {
     },
   },
   AutoSuggestion: {
-    name: autoSuggestion => autoSuggestion.title
+    name: autoSuggestion => autoSuggestion.title.replace("&#039;", "'")
   }
 }
 

--- a/src/apollo/server/resolvers/searchResolver.js
+++ b/src/apollo/server/resolvers/searchResolver.js
@@ -52,7 +52,7 @@ const searchResolver = {
   },
   OnlineResourceDocument: {
     id: document => document.uuid,
-    name: document => document.title,
+    name: document => document.title.replace("&#039;", "'"),
     description: document => document.summary,
     slug: document => document.path,
     mostPopular: document => document['most-popular'],

--- a/src/components/online-resources/OnlineResourceCard/OnlineResourceCard.js
+++ b/src/components/online-resources/OnlineResourceCard/OnlineResourceCard.js
@@ -74,7 +74,9 @@ function OnlineResourceCard({ item, collapsible, ipInfo }) {
           </StatusBadge>
         </div>
       }
-      <div>{description}</div>
+      <div dangerouslySetInnerHTML={{
+        __html: description 
+      }}></div>
       <div className={s.links}>
         <DsLink
           href={accessibilityLink}


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-2309)

**This PR does the following:**
- Removes html entities from title field (this is a temp workaround, as this should really happen on the Drupal side)
- Changes OnlineResourceCard description field to render as html
- Preview Env: https://pr149-owtxo5pjjmxbdqyqppmshs3iixtd7hsf.tugboat.qa/research/collections/online-resources

### Review Steps:
- [ ] Compare to QA, doing a search for "Bartlett" will return a title in the autosuggest that contains html entity encoded -- https://qa-www.nypl.org/research/collections/online-resources
- [ ] Do the same search here: https://pr149-owtxo5pjjmxbdqyqppmshs3iixtd7hsf.tugboat.qa/research/collections/online-resources -- and this should be removed.
- [ ] To test the Card description change, search for "Brainfuse" and the description should have the "strong" tags rendered as HTML

