### PR TITLE
RENO-2407: Database Title Should Appear as a Link For Some IP Addresses

### DIFF
--- a/src/apollo/client/queries/LocationMatchesByIp.gql
+++ b/src/apollo/client/queries/LocationMatchesByIp.gql
@@ -3,6 +3,7 @@ query LocationMatchesByIpQuery($ip: String) {
     items {
       id
       name
+      locationId
     }
     pageInfo {
       clientIp

--- a/src/apollo/server/type-defs/search.js
+++ b/src/apollo/server/type-defs/search.js
@@ -47,6 +47,10 @@ export const typeDefs = gql`
     pageInfo: PageInfo
   }
 
+  type SearchDocumentConnect {
+    
+  }
+
   input SearchDocumentFilter {
     q: String,
     tid: String,

--- a/src/apollo/server/type-defs/search.js
+++ b/src/apollo/server/type-defs/search.js
@@ -47,10 +47,6 @@ export const typeDefs = gql`
     pageInfo: PageInfo
   }
 
-  type SearchDocumentConnect {
-    
-  }
-
   input SearchDocumentFilter {
     q: String,
     tid: String,

--- a/src/components/online-resources/OnlineResourceCard/OnlineResourceCardHeading.js
+++ b/src/components/online-resources/OnlineResourceCard/OnlineResourceCardHeading.js
@@ -5,7 +5,6 @@ import Link from 'next/link';
 import { ONLINE_RESOURCES_BASE_PATH } from './../../../utils/config';
 
 function OnlineResourceCardHeading(props) {
-  console.log(props)
   const { 
     id, 
     name, 
@@ -30,7 +29,6 @@ function OnlineResourceCardHeading(props) {
   
     const linkAccess = locationMatchesArray
       .filter(e => accessLocationsArray.includes(e));
-    
     return linkAccess.length;
   }
 

--- a/src/components/online-resources/OnlineResourceCard/OnlineResourceCardHeading.js
+++ b/src/components/online-resources/OnlineResourceCard/OnlineResourceCardHeading.js
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { ONLINE_RESOURCES_BASE_PATH } from './../../../utils/config';
 
 function OnlineResourceCardHeading(props) {
+  console.log(props)
   const { 
     id, 
     name, 
@@ -29,7 +30,7 @@ function OnlineResourceCardHeading(props) {
   
     const linkAccess = locationMatchesArray
       .filter(e => accessLocationsArray.includes(e));
-        
+    
     return linkAccess.length;
   }
 

--- a/src/pages/research/collections/articles-databases/[slug].js
+++ b/src/pages/research/collections/articles-databases/[slug].js
@@ -33,6 +33,7 @@ function OnlineResourceSlug() {
   const client = useApolloClient();
   // Local state.
   const [ipInfo, setIpInfo] = useState();
+  const [clientIpAddress, setClientIpAddress] = useState();
   // Run a client query after page renders to ensure that the ip address
   // checking is not ssr, but from the client.
   useEffect(() => {
@@ -43,7 +44,8 @@ function OnlineResourceSlug() {
       }
     }).then(
       response => {
-        setIpInfo(response.data ? response.data : null)
+        setIpInfo(response.data ? response.data : null);
+        setClientIpAddress(response.data?.allLocationMatches?.pageInfo.clientIp);
       },
       error => {
         //console.error(error);
@@ -112,6 +114,14 @@ function OnlineResourceSlug() {
       showContentHeader={true}
       contentPrimary={
         <Fragment>
+          {router.query.test_ip && clientIpAddress &&
+            <strong>**TEST MODE** Your IP address is: {clientIpAddress}</strong>
+          }
+          {clientIpAddress && 
+            <div>
+              <h3>IP Address: {clientIpAddress}</h3>
+            </div>
+          }
           <OnlineResourceCard item={data.searchDocument} ipInfo={ipInfo} />
         </Fragment>
       }

--- a/src/pages/research/collections/articles-databases/[slug].js
+++ b/src/pages/research/collections/articles-databases/[slug].js
@@ -1,9 +1,9 @@
-import React, { Fragment, useEffect } from 'react';
+import React, { Fragment, useEffect, useState } from 'react';
 // Next
 import Router, { useRouter } from 'next/router';
 // Apollo
 import { getDataFromTree } from '@apollo/client/react/ssr';
-import { useQuery } from '@apollo/client';
+import { useQuery, useApolloClient } from '@apollo/client';
 import { withApollo } from './../../../../apollo/client/withApollo';
 import { 
   DecoupledRouterQuery as DECOUPLED_ROUTER_QUERY 
@@ -11,6 +11,9 @@ import {
 import {
   OnlineResourceByIdQuery as ONLINE_RESOURCE_BY_ID_QUERY
 } from './../../../../apollo/client/queries/OnlineResourceById.gql';
+import {
+  LocationMatchesByIpQuery as LOCATION_MATCHES_BY_IP_QUERY
+} from './../../../../apollo/client/queries/LocationMatchesByIp.gql';
 // Redux
 import { withRedux } from './../../../../redux/withRedux';
 // Components
@@ -25,6 +28,28 @@ import onlineResourcesContent from './../../../../__content/onlineResources';
 function OnlineResourceSlug() {
   const router = useRouter();
   const { slug } = router.query;
+  
+  // Apollo.
+  const client = useApolloClient();
+  // Local state.
+  const [ipInfo, setIpInfo] = useState();
+  // Run a client query after page renders to ensure that the ip address
+  // checking is not ssr, but from the client.
+  useEffect(() => {
+    client.query({ 
+      query: LOCATION_MATCHES_BY_IP_QUERY,
+      variables: {
+        ip: router.query.test_ip ? router.query.test_ip : null
+      }
+    }).then(
+      response => {
+        setIpInfo(response.data ? response.data : null)
+      },
+      error => {
+        //console.error(error);
+      }
+    );
+  }, []);
 
   // Run decoupled router query to get uuid.
   const { data: decoupledRouterData } = useQuery(
@@ -87,7 +112,7 @@ function OnlineResourceSlug() {
       showContentHeader={true}
       contentPrimary={
         <Fragment>
-          <OnlineResourceCard item={data.searchDocument} />
+          <OnlineResourceCard item={data.searchDocument} ipInfo={ipInfo} />
         </Fragment>
       }
     />


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-2407)

**This PR does the following:**
- Wires up the detail pages to use ip address to determine if a plain text heading or link is displayed

### Review Steps:
- [ ] If you go here with the page in "IP Test Mode", you should see "D&B Hoovers" as a link https://pr176-1gf8gnuzk6bctffksa12y35q7kw4koeb.tugboat.qa/research/collections/articles-databases/db-hoovers?test_ip=65.88.88.193
- [ ] If you just goto the regular url, the "D&B Hoovers" should be plain text and not a link: https://pr176-1gf8gnuzk6bctffksa12y35q7kw4koeb.tugboat.qa/research/collections/articles-databases/db-hoovers

