### PR TITLE
RENO-2776: Bug Fix for Text with Image Component, Image Field Not Required

### DIFF
--- a/src/apollo/server/resolvers/utils/resolveDrupalParagraphs.ts
+++ b/src/apollo/server/resolvers/utils/resolveDrupalParagraphs.ts
@@ -103,7 +103,10 @@ export default function resolveDrupalParagraphs(
           credit: textWithImageMedia.field_media_image_credit_html
             ? textWithImageMedia.field_media_image_credit_html.processed
             : null,
-          image: resolveImage(item.field_ers_media_item),
+          image:
+            item.field_ers_media_item.data === null
+              ? null
+              : resolveImage(item.field_ers_media_item),
         };
         break;
       case "paragraph--video":

--- a/src/components/shared/ContentComponents/TextWithImage.tsx
+++ b/src/components/shared/ContentComponents/TextWithImage.tsx
@@ -32,9 +32,9 @@ function TextWithImage({
       {image && (
         <Box
           width="100%"
-          maxWidth={[null, null, "50%"]}
-          float={[null, null, "left"]}
-          mr={[null, null, "m"]}
+          maxWidth={{ lg: "50%" }}
+          float={{ lg: "left" }}
+          mr={{ lg: "m" }}
         >
           <img
             id={image.id}

--- a/src/components/shared/ContentComponents/TextWithImage.tsx
+++ b/src/components/shared/ContentComponents/TextWithImage.tsx
@@ -4,7 +4,6 @@ import {
   Heading,
   HeadingLevels,
 } from "@nypl/design-system-react-components";
-import Image from "../../shared/Image";
 // Utils
 import { getImageTransformation } from "./../../shared/Image/imageUtils";
 
@@ -15,7 +14,7 @@ interface TextWithImageProps {
   text: string;
   caption?: string;
   credit?: string;
-  image: any;
+  image?: any;
 }
 
 function TextWithImage({
@@ -30,41 +29,32 @@ function TextWithImage({
   return (
     <Box id={`${type}-${id}`} mb="xl">
       {heading && <Heading level={HeadingLevels.Two} text={heading} />}
-      <Box
-        width="100%"
-        maxWidth={[null, null, "50%"]}
-        float={[null, null, "left"]}
-        mr={[null, null, "m"]}
-      >
-        <img
-          src={getImageTransformation("max_width_960", image.transformations)}
-        />
-        {/*<Image
-          id={image.id}
-          alt={image.alt}
-          uri={image.uri}
-          useTransformation={true}
-          transformations={image.transformations}
-          transformationLabel={"medium"}
-          layout="intrinsic"
-          width={960}
-          height={450}
-          quality={90}
-        />
-        */}
-        {caption && (
-          <Box fontSize="-1" fontWeight="regular">
-            {caption}
-          </Box>
-        )}
-        {credit && (
-          <Box
-            fontSize="-3"
-            fontStyle="italic"
-            dangerouslySetInnerHTML={{ __html: credit }}
+      {image && (
+        <Box
+          width="100%"
+          maxWidth={[null, null, "50%"]}
+          float={[null, null, "left"]}
+          mr={[null, null, "m"]}
+        >
+          <img
+            id={image.id}
+            alt={image.alt}
+            src={getImageTransformation("max_width_960", image.transformations)}
           />
-        )}
-      </Box>
+          {caption && (
+            <Box fontSize="-1" fontWeight="regular">
+              {caption}
+            </Box>
+          )}
+          {credit && (
+            <Box
+              fontSize="-3"
+              fontStyle="italic"
+              dangerouslySetInnerHTML={{ __html: credit }}
+            />
+          )}
+        </Box>
+      )}
       <Box dangerouslySetInnerHTML={{ __html: text }} />
       <Box
         as="span"


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-2776)

**This PR does the following:**
- In Drupal 9 backend, the "Text With Image" component does not require an image to be added. This was causing a bug on the frontend, where the React component expected there to always be an image. So the work here checks if there is an image, and if not, will skip rendering that portion of the component. Example of bug on QA:
https://qa-scout.nypl.org/blog/2022/03/01/qa-blog-reno-2680?preview_secret=o934Ysf3Hpu3irVXFBYvGCAyHjU3F&uuid=8d885904-0553-4073-b82d-2da729c94338&revision_id=34638

### Review Steps:
- [ ] Update your local .env variables with the following values for these vars:
```
NEXT_PUBLIC_DRUPAL_PREVIEW_SECRET=o934Ysf3Hpu3irVXFBYvGCAyHjU3F
DRUPAL_CONSUMER_UUID=7af062d8-1b9d-4d81-81b7-a4f681a651d4
DRUPAL_CONSUMER_SECRET=test1234
```
- [ ] Run `git fetch` to get latest branches
- [ ] Checkout this branch `git checkout RENO-2776/text-with-image-bug`
- [ ] Start the app `npm run dev`
- [ ] Goto this url locally: http://localhost:3000/blog/2022/03/01/qa-blog-reno-2680?preview_secret=o934Ysf3Hpu3irVXFBYvGCAyHjU3F&uuid=8d885904-0553-4073-b82d-2da729c94338&revision_id=34638 -- Page should render without error like on QA

### Front End Review Steps:
- [ ] View [Example](http://localhost:3000/)
