### PR TITLE
RENO-2793: Pagination Bug Fixes

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,3 +1,4 @@
 {
+  "baseUrl": "http://localhost:3000",
   "integrationFolder": "cypress/tests"
 }

--- a/cypress/tests/blogs/blogs-all.test.js
+++ b/cypress/tests/blogs/blogs-all.test.js
@@ -8,6 +8,16 @@ describe("Blog All pg tests", () => {
     cy.viewport(1024, 768);
   });
 
+  it("Breadcrumbs includes page title and its not a link", () => {});
+
+  it("Filter bar with 5 multiselects are present", () => {});
+
+  it("First 10 blog posts are present", () => {});
+
+  it("Next page pagination button takes user to page 2", () => {});
+
+  it("Clicking 3 link in pagination takes user to page 3", () => {});
+
   it("Filter bar should reset pagination", () => {
     cy.log("Goto blogs all page starting at page 15");
     cy.visit("http://localhost:3000/blog/all?page=15");

--- a/cypress/tests/blogs/blogs-all.test.js
+++ b/cypress/tests/blogs/blogs-all.test.js
@@ -1,8 +1,3 @@
-/* eslint-disable */
-// Disable ESLint to prevent failing linting inside the Next.js repo.
-// If you're using ESLint on your project, we recommend installing the ESLint Cypress plugin instead:
-// https://github.com/cypress-io/eslint-plugin-cypress
-
 describe("Blog All pg tests", () => {
   beforeEach(() => {
     cy.viewport(1024, 768);
@@ -22,7 +17,7 @@ describe("Blog All pg tests", () => {
 
   it("Filter bar should reset pagination when applied", () => {
     cy.log("Goto blogs all page starting at page 15");
-    cy.visit("http://localhost:3000/blog/all?page=15");
+    cy.visit("/blog/all?page=15");
 
     const items = ["Black Culture", "Book Lists"];
     const queryParams = "channel=730+734";
@@ -55,7 +50,7 @@ describe("Blog All pg tests", () => {
   });
 
   it("10 blog posts should display on first page", () => {
-    cy.visit("http://localhost:3000/blog/all");
+    cy.visit("/blog/all");
     cy.log("Get blog collection by test id");
     cy.get("[data-testid=blog-collection]")
       .find("li")
@@ -65,6 +60,7 @@ describe("Blog All pg tests", () => {
   it("Clicking next link in pagination takes user to page 2", () => {});
 
   it("Clicking page 3 link in pagination takes user to page 3", () => {
+    cy.visit("/blog/all");
     cy.log("Find the pagination component");
     cy.findByRole("navigation", {
       name: /pagination/i,

--- a/cypress/tests/blogs/blogs-all.test.js
+++ b/cypress/tests/blogs/blogs-all.test.js
@@ -10,19 +10,15 @@ describe("Blog All pg tests", () => {
 
   it("Breadcrumbs includes page title as last item and is not a link", () => {});
 
+  it("Hero should include h1 title and description", () => {});
+
+  it("Right rail menu should be present in sidebar", () => {});
+
   it("Filter bar with 5 multiselects are present", () => {});
 
-  it("10 blog posts should display on first page", () => {
-    cy.visit("http://localhost:3000/blog/all");
-    cy.log("Get blog collection by test id");
-    cy.get("[data-testid=blog-collection]")
-      .find("li")
-      .should("have.length", 10);
-  });
+  it("Filter bar with selected items from 1 multiselect should update page", () => {});
 
-  it("Next page pagination button takes user to page 2", () => {});
-
-  it("Clicking page 3 link in pagination takes user to page 3", () => {});
+  it("Filter bar with selected items from several multiselect should update page", () => {});
 
   it("Filter bar should reset pagination when applied", () => {
     cy.log("Goto blogs all page starting at page 15");
@@ -55,6 +51,32 @@ describe("Blog All pg tests", () => {
     cy.log("Pagination should be reset to page 1 in the url");
     cy.location().should((loc) => {
       expect(loc.search).to.eq(`?${queryParams}&page=1`);
+    });
+  });
+
+  it("10 blog posts should display on first page", () => {
+    cy.visit("http://localhost:3000/blog/all");
+    cy.log("Get blog collection by test id");
+    cy.get("[data-testid=blog-collection]")
+      .find("li")
+      .should("have.length", 10);
+  });
+
+  it("Clicking next link in pagination takes user to page 2", () => {});
+
+  it("Clicking page 3 link in pagination takes user to page 3", () => {
+    cy.log("Find the pagination component");
+    cy.findByRole("navigation", {
+      name: /pagination/i,
+    }).within(() => {
+      cy.log("Find page 3 link");
+      cy.findByRole("link", {
+        name: "Page 3",
+      }).click();
+    });
+    cy.log("Pagination should be on page 3");
+    cy.location().should((loc) => {
+      expect(loc.search).to.eq(`?page=3`);
     });
   });
 });

--- a/cypress/tests/blogs/blogs-all.test.js
+++ b/cypress/tests/blogs/blogs-all.test.js
@@ -1,0 +1,44 @@
+/* eslint-disable */
+// Disable ESLint to prevent failing linting inside the Next.js repo.
+// If you're using ESLint on your project, we recommend installing the ESLint Cypress plugin instead:
+// https://github.com/cypress-io/eslint-plugin-cypress
+
+describe("Blog All pg tests", () => {
+  beforeEach(() => {
+    cy.viewport(1024, 768);
+  });
+
+  it("Filter bar should reset pagination", () => {
+    cy.log("Goto blogs all page starting at page 15");
+    cy.visit("http://localhost:3000/blog/all?page=15");
+
+    const items = ["Black Culture", "Book Lists"];
+    const queryParams = "channel=730+734";
+
+    cy.log("Open multiselect menu");
+    cy.get("#blogs__filter-bar")
+      .findByRole("button", { name: "Channels" })
+      .click();
+    // Map over items to select them from multiselect.
+    items.map((item) => {
+      cy.log("Select item from multiselect");
+      cy.get("#multiselect-channel")
+        .findByRole("dialog")
+        .findByLabelText(item)
+        // { force: true } might be necessary here, expained here:
+        // https://github.com/chakra-ui/chakra-ui/issues/3955
+        .click({ force: true })
+        .should("be.checked");
+    });
+
+    cy.log("Submit multiselect");
+    cy.get("#multiselect-channel")
+      .findByRole("button", { name: "Apply Filters" })
+      .click();
+
+    cy.log("Pagination should be reset to page 1 in the url");
+    cy.location().should((loc) => {
+      expect(loc.search).to.eq(`?${queryParams}&page=1`);
+    });
+  });
+});

--- a/cypress/tests/blogs/blogs-all.test.js
+++ b/cypress/tests/blogs/blogs-all.test.js
@@ -8,17 +8,23 @@ describe("Blog All pg tests", () => {
     cy.viewport(1024, 768);
   });
 
-  it("Breadcrumbs includes page title and its not a link", () => {});
+  it("Breadcrumbs includes page title as last item and is not a link", () => {});
 
   it("Filter bar with 5 multiselects are present", () => {});
 
-  it("First 10 blog posts are present", () => {});
+  it("10 blog posts should display on first page", () => {
+    cy.visit("http://localhost:3000/blog/all");
+    cy.log("Get blog collection by test id");
+    cy.get("[data-testid=blog-collection]")
+      .find("li")
+      .should("have.length", 10);
+  });
 
   it("Next page pagination button takes user to page 2", () => {});
 
-  it("Clicking 3 link in pagination takes user to page 3", () => {});
+  it("Clicking page 3 link in pagination takes user to page 3", () => {});
 
-  it("Filter bar should reset pagination", () => {
+  it("Filter bar should reset pagination when applied", () => {
     cy.log("Goto blogs all page starting at page 15");
     cy.visit("http://localhost:3000/blog/all?page=15");
 

--- a/cypress/tests/blogs/blogs-main.test.js
+++ b/cypress/tests/blogs/blogs-main.test.js
@@ -1,7 +1,7 @@
 describe("Blogs Main Tests", () => {
   beforeEach(() => {
     cy.viewport(1024, 768);
-    cy.visit("http://localhost:3000/blog");
+    cy.visit("/blog");
   });
 
   it("Basic smoke test.", () => {

--- a/src/apollo/server/type-defs/blog.js
+++ b/src/apollo/server/type-defs/blog.js
@@ -40,6 +40,7 @@ export const typeDefs = gql`
 
   input BlogFilter {
     featured: QueryFilterItemBoolean
+    status: QueryFilterItemBoolean
     channels: QueryFilterItemReference
     subjects: QueryFilterItemReference
     libraries: QueryFilterItemReference

--- a/src/components/blogs/BlogsContainer/BlogsContainer.tsx
+++ b/src/components/blogs/BlogsContainer/BlogsContainer.tsx
@@ -222,11 +222,21 @@ function BlogsContainer({
         </Grid>
       </CardSet>
       {!featured && (
-        <Pagination
-          initialPage={currentPage}
-          pageCount={data.allBlogs.pageInfo.pageCount}
-          onPageChange={onPageChange}
-        />
+        <Box
+          sx={{
+            // Centers the pagination component.
+            "& nav[role=navigation]": {
+              justifyContent: "center",
+            },
+          }}
+          data-testid="blog-pagination"
+        >
+          <Pagination
+            initialPage={currentPage}
+            pageCount={data.allBlogs.pageInfo.pageCount}
+            onPageChange={onPageChange}
+          />
+        </Box>
       )}
     </>
   );

--- a/src/components/blogs/BlogsContainer/BlogsContainer.tsx
+++ b/src/components/blogs/BlogsContainer/BlogsContainer.tsx
@@ -50,6 +50,7 @@ interface BlogsContainerProps {
   pageNumber?: number;
   sort?: any;
   featured?: boolean;
+  status?: boolean;
 }
 
 function BlogsContainer({
@@ -62,6 +63,7 @@ function BlogsContainer({
   pageNumber,
   sort,
   featured,
+  status,
 }: BlogsContainerProps) {
   const router = useRouter();
   const currentPage = router.query.page
@@ -111,6 +113,14 @@ function BlogsContainer({
       fieldName: "field_bs_featured",
       operator: "=",
       value: featured,
+    };
+  }
+  // Published
+  if (status) {
+    queryFilters["status"] = {
+      fieldName: "status",
+      operator: "=",
+      value: status,
     };
   }
 

--- a/src/components/blogs/BlogsContainer/BlogsContainer.tsx
+++ b/src/components/blogs/BlogsContainer/BlogsContainer.tsx
@@ -3,8 +3,7 @@ import React from "react";
 import { gql, useQuery } from "@apollo/client";
 import { BLOG_FIELDS_FRAGMENT } from "./../../../apollo/client/fragments/blogFields";
 // Components
-import { Pagination } from "@nypl/design-system-react-components";
-import CardGrid from "../../ds-prototypes/CardGrid";
+import { Box, Grid, Pagination } from "@nypl/design-system-react-components";
 import CardSet from "../../shared/Card/CardSet";
 import CardSkeletonLoader from "../../shared/Card/CardSkeletonLoader";
 import BlogCard from "./BlogCard";
@@ -191,7 +190,7 @@ function BlogsContainer({
   return (
     <>
       {showFilterBar && (
-        <div style={{ paddingBottom: "2rem" }}>
+        <Box pb="l">
           <FilterBarDetails
             currentPage={currentPage}
             itemsOnPage={data.allBlogs.items.length}
@@ -199,7 +198,7 @@ function BlogsContainer({
             limit={limit}
             totalItems={data.allBlogs.pageInfo.totalItems}
           />
-        </div>
+        </Box>
       )}
       <CardSet
         id={id}
@@ -208,13 +207,19 @@ function BlogsContainer({
         slugLabel={slugLabel}
         description={description}
       >
-        <CardGrid gap="2rem" templateColumns="repeat(1, 1fr)">
+        <Grid
+          as="ul"
+          gap="l"
+          templateColumns="repeat(1, 1fr)"
+          listStyleType="none"
+          data-testid="blog-collection"
+        >
           {data.allBlogs.items.map((item: BlogCardItem) => (
             <li key={item.id}>
               <BlogCard item={item} />
             </li>
           ))}
-        </CardGrid>
+        </Grid>
       </CardSet>
       {!featured && (
         <Pagination

--- a/src/components/shared/FilterBar/FilterBar.tsx
+++ b/src/components/shared/FilterBar/FilterBar.tsx
@@ -176,7 +176,8 @@ function FilterBar({
             q: router.query.q,
           }),
           ...queryParamsToAdd,
-          page: router.query.page ? router.query.page : 1,
+          //page: router.query.page ? router.query.page : 1,
+          page: 1,
         },
       })
       .then(() => {

--- a/src/components/shared/FilterBar/FilterBar.tsx
+++ b/src/components/shared/FilterBar/FilterBar.tsx
@@ -176,7 +176,6 @@ function FilterBar({
             q: router.query.q,
           }),
           ...queryParamsToAdd,
-          //page: router.query.page ? router.query.page : 1,
           page: 1,
         },
       })

--- a/src/pages/blog/all.tsx
+++ b/src/pages/blog/all.tsx
@@ -28,6 +28,7 @@ function BlogsAllPage() {
           id="all-blogs"
           limit={10}
           sort={{ field: "created", direction: "DESC" }}
+          status={true}
         />
       }
     />

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -28,6 +28,7 @@ function BlogsMainPage() {
             limit={6}
             featured={true}
             sort={{ field: "created", direction: "DESC" }}
+            status={true}
           />
           <ChannelsCards
             id="explore-by-channel"


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-2793)

**This PR does the following:**
- Fixes bug where filter bar was not reseting pagination to page 1
- Fixes bug where unpublished blog posts were throwing off page count and pagination, by adding `status`, so only published blog posts are specifically queries for.
- First draft of Blogs all pg tests

### Review Steps:
- [ ] Pull in latest code `git fetch && git checkout RENO-2793/pagination-bug`
- [ ] Start app `npm run dev`
- [ ] To test "reset pagination" goto `http://localhost:3000/blog/all?page=15`
- [ ] From "Libraries" multiselect, select "125th Street Library" and click apply
- [ ] Pagination should get reset and url should now be `http://localhost:3000/blog/all?library=39&page=1`

### Front End Review Steps:
- [ ] View [Example](http://localhost:3000/blog/all)
