### PR TITLE
RENO-2806: Update Breadcrumbs to Use Blog Singular

### DIFF
--- a/src/__content/blogs.js
+++ b/src/__content/blogs.js
@@ -8,7 +8,7 @@ const blogsContent = {
     heading: "Featured Posts",
     description: "Take a look at the latest posts from the NYPL Blog:",
     slug: "/blog/all",
-    slugLabel: "View all blogs",
+    slugLabel: "View all blog posts",
   },
   explore_by_channel: {
     heading: "Explore By Channel",

--- a/src/components/blogs/layouts/PageContainer.js
+++ b/src/components/blogs/layouts/PageContainer.js
@@ -33,7 +33,7 @@ function PageContainer(props) {
       url: `${NEXT_PUBLIC_NYPL_DOMAIN}`,
     },
     {
-      text: "Blogs",
+      text: "Blog",
       url: `${NEXT_PUBLIC_NYPL_DOMAIN}${BLOGS_BASE_PATH}`,
     },
   ];

--- a/src/pages/blog/all.tsx
+++ b/src/pages/blog/all.tsx
@@ -18,7 +18,7 @@ function BlogsAllPage() {
       }}
       breadcrumbs={[
         {
-          text: "All Blogs",
+          text: "All",
         },
       ]}
       showContentHeader={true}


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-2806)

**This PR does the following:**
- Updates breadcrumbs and cta to use "Blog" instead of "Blogs"

