### PR TITLE
Reno 2717/location finder fixes

### DIFF
--- a/src/components/location-finder/Location/Location.tsx
+++ b/src/components/location-finder/Location/Location.tsx
@@ -78,7 +78,9 @@ function Location({ location }: LocationProps) {
       <Box mb="xxs" whiteSpace="pre-wrap" className="address">
         {formattedAddress}
       </Box>
-      <Box className="phone">{location.phone}</Box>
+      <Box mb="xxs" className="phone">
+        {location.phone}
+      </Box>
       <LocationAccessibility
         access={location.wheelchairAccess}
         note={location.accessibilityNote}

--- a/src/components/location-finder/Location/Location.tsx
+++ b/src/components/location-finder/Location/Location.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import {
   Box,
   Button,
@@ -70,10 +71,14 @@ function Location({ location }: LocationProps) {
         <Link href={location.url}>{location.name}</Link>
       </Heading>
       {location.parentLibraryName && (
-        <div className="location__parent">{location.parentLibraryName}</div>
+        <Box fontStyle="italic" className="location__parent">
+          {location.parentLibraryName}
+        </Box>
       )}
-      <div className="address">{formattedAddress}</div>
-      <div className="phone">{location.phone}</div>
+      <Box whiteSpace="pre-wrap" className="address">
+        {formattedAddress}
+      </Box>
+      <Box className="phone">{location.phone}</Box>
       <LocationAccessibility
         access={location.wheelchairAccess}
         note={location.accessibilityNote}

--- a/src/components/location-finder/Location/Location.tsx
+++ b/src/components/location-finder/Location/Location.tsx
@@ -75,7 +75,7 @@ function Location({ location }: LocationProps) {
           {location.parentLibraryName}
         </Box>
       )}
-      <Box whiteSpace="pre-wrap" className="address">
+      <Box mb="xxs" whiteSpace="pre-wrap" className="address">
         {formattedAddress}
       </Box>
       <Box className="phone">{location.phone}</Box>

--- a/src/components/location-finder/Location/LocationAccessibility.test.js
+++ b/src/components/location-finder/Location/LocationAccessibility.test.js
@@ -1,75 +1,65 @@
-import React from 'react';
-import { screen } from '@testing-library/react';
-import { axe, toHaveNoViolations } from 'jest-axe';
-import '@testing-library/jest-dom/extend-expect';
-import { render } from './../../../../testHelper/customRtlRender';
-import LocationAccessibility from './LocationAccessibility';
+import React from "react";
+import { screen } from "@testing-library/react";
+import { axe, toHaveNoViolations } from "jest-axe";
+import "@testing-library/jest-dom/extend-expect";
+import { render } from "./../../../../testHelper/customRtlRender";
+import LocationAccessibility from "./LocationAccessibility";
 
 expect.extend(toHaveNoViolations);
 
 // Mock accessibility access
-const access_full = 'full';
-const note = '';
+const access_full = "full";
+const note = "";
 
-describe('LocationAccessibility', () => {
-  test('renders LocationAccessibility component', () => {
-    render(
-      <LocationAccessibility access={access_full} note={note} />
-    );
+describe("LocationAccessibility", () => {
+  test("renders LocationAccessibility component", () => {
+    render(<LocationAccessibility access={access_full} note={note} />);
   });
 
   // Test accessibility access 1
   // Access: Fully Accessible
-  test('Location should be fully accessible', () => {
-    render(
-      <LocationAccessibility access={access_full} note={note} />
-    );
+  test("Location should be fully accessible", () => {
+    render(<LocationAccessibility access={access_full} note={note} />);
 
-    expect(screen.getByText('Fully Accessible')).toBeInTheDocument();
+    expect(screen.getByText("Fully Accessible")).toBeInTheDocument();
   });
 
   // Test accessibility access 2
   // Access: Partially Accessible
-  const access_partial = 'partial';
-  const note_partial = 'All parts of the library, with the exception of the computer classroom and community room, are wheelchair accessible';
+  const access_partial = "partial";
+  const note_partial =
+    "All parts of the library, with the exception of the computer classroom and community room, are wheelchair accessible";
 
-  test('Location should be partially accessible', () => {
+  test("Location should be partially accessible", () => {
     render(
       <LocationAccessibility access={access_partial} note={note_partial} />
     );
 
     expect(screen.getByText(/Partially Accessible/)).toBeInTheDocument();
-
   });
 
   // Test accessibility access 3
   // Access: Not Accessible
-  const access_none = 'none';
+  const access_none = "none";
 
-  test('Location should be not accessible', () => {
-    render(
-      <LocationAccessibility access={access_none} note={note} />
-    );
+  test("Location should be not accessible", () => {
+    render(<LocationAccessibility access={access_none} note={note} />);
 
-    expect(screen.getByText('Not Accessible')).toBeInTheDocument();
+    expect(screen.getByText("Not Accessible")).toBeInTheDocument();
   });
 
   // Test accessibility access 4
   // Access: Fullt Accessible
   // Note: none
-  test('Location should be fully accessible and has no notes', () => {
-    render(
-      <LocationAccessibility access={access_full} note={note} />
-    );
+  test("Location should be fully accessible and has no notes", () => {
+    render(<LocationAccessibility access={access_full} note={note} />);
 
-    expect(screen.getByText('Fully Accessible')).toBeInTheDocument();
+    expect(screen.getByText("Fully Accessible")).toBeInTheDocument();
   });
-
 });
 
-
 // Accessbiility tests.
-it('should not have basic accessibility issues', async () => {
+it("should not have basic accessibility issues", async () => {
   const { container } = render(
     <LocationAccessibility access={access_full} note={note} />
   );

--- a/src/components/location-finder/Location/LocationAccessibility.tsx
+++ b/src/components/location-finder/Location/LocationAccessibility.tsx
@@ -46,7 +46,7 @@ function LocationAccessibility({ access, note }: LocationAccessibilityProps) {
   }
   return (
     <HStack mb="xxs" align="center">
-      <Box>{wheelchairAccessIcon}</Box>
+      <Box maxHeight={"24px"}>{wheelchairAccessIcon}</Box>
       <Box>
         {wheelchairAccess} {accessibilityNote}
       </Box>

--- a/src/components/location-finder/Location/LocationAccessibility.tsx
+++ b/src/components/location-finder/Location/LocationAccessibility.tsx
@@ -45,8 +45,8 @@ function LocationAccessibility({ access, note }: LocationAccessibilityProps) {
     accessibilityNote = `: ${note}`;
   }
   return (
-    <HStack mb="xxs" align="center">
-      <Box maxHeight={"24px"}>{wheelchairAccessIcon}</Box>
+    <HStack align="flex-start">
+      <Box>{wheelchairAccessIcon}</Box>
       <Box>
         {wheelchairAccess} {accessibilityNote}
       </Box>

--- a/src/components/location-finder/Location/LocationAccessibility.tsx
+++ b/src/components/location-finder/Location/LocationAccessibility.tsx
@@ -45,7 +45,7 @@ function LocationAccessibility({ access, note }: LocationAccessibilityProps) {
     accessibilityNote = `: ${note}`;
   }
   return (
-    <HStack align="center">
+    <HStack mb="xxs" align="center">
       <Box>{wheelchairAccessIcon}</Box>
       <Box>
         {wheelchairAccess} {accessibilityNote}

--- a/src/components/location-finder/Location/LocationHours.tsx
+++ b/src/components/location-finder/Location/LocationHours.tsx
@@ -67,7 +67,7 @@ function LocationHours({
         </StatusBadge>
       )}
       {appointmentOnly && todayHoursStart && todayHoursEnd && (
-        <Box pl={8} fontWeight="bold">
+        <Box ml="l" fontWeight="bold">
           * Division is by appointment only.
         </Box>
       )}

--- a/src/components/location-finder/Location/LocationHours.tsx
+++ b/src/components/location-finder/Location/LocationHours.tsx
@@ -54,7 +54,7 @@ function LocationHours({
   return (
     <>
       {open ? (
-        <HStack align="center">
+        <HStack mb="xxs" align="center">
           <Icon name={IconNames.Clock} size={IconSizes.Large} />
           <Box>Today's Hours:</Box>
           <Box fontWeight="bold">

--- a/src/components/location-finder/Location/LocationHours.tsx
+++ b/src/components/location-finder/Location/LocationHours.tsx
@@ -57,7 +57,7 @@ function LocationHours({
         <HStack align="center">
           <Icon name={IconNames.Clock} size={IconSizes.Large} />
           <Box>Today's Hours:</Box>
-          <Box>
+          <Box fontWeight="bold">
             {formatHours(todayHoursStart, todayHoursEnd, appointmentOnly)}
           </Box>
         </HStack>
@@ -67,7 +67,9 @@ function LocationHours({
         </StatusBadge>
       )}
       {appointmentOnly && todayHoursStart && todayHoursEnd && (
-        <Box>* Division is by appointment only.</Box>
+        <Box pl={8} fontWeight="bold">
+          * Division is by appointment only.
+        </Box>
       )}
     </>
   );

--- a/src/pages/locations/index.tsx
+++ b/src/pages/locations/index.tsx
@@ -24,6 +24,7 @@ import {
 } from "@nypl/design-system-react-components";
 // Content + config
 const { NEXT_PUBLIC_NYPL_DOMAIN } = process.env;
+import { LOCATIONS_BASE_PATH } from "./../../utils/config";
 import { railMenuContent } from "./../../__content/menus";
 
 function LocationFinder() {
@@ -38,6 +39,10 @@ function LocationFinder() {
         {
           text: "Home",
           url: `${NEXT_PUBLIC_NYPL_DOMAIN}`,
+        },
+        {
+          text: "Locations",
+          url: `${NEXT_PUBLIC_NYPL_DOMAIN}${LOCATIONS_BASE_PATH}`,
         },
       ]}
       breadcrumbsColor={ColorVariants.Locations}

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -5,5 +5,7 @@ export const ONLINE_RESOURCES_ALL_BRANCH_UUID = "all-branch-uuid";
 export const ONLINE_RESOURCES_ALL_RESEARCH_UUID = "all-research-uuid";
 export const ONLINE_RESOURCES_OFFSITE_UUID = "offsite-uuid";
 export const ONLINE_RESOURCES_ONSITE_UUID = "on-site-uuid";
+//Locations
+export const LOCATIONS_BASE_PATH = "/locations";
 // Blogs
 export const BLOGS_BASE_PATH = "/blog";


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browseRENO-2790)

**This PR does the following:**
- change location address to be multi-line
- change parent library to italic
- set hours to bold 
- fix layout of  "* Division is by appointment only."
- add /Locations to breadcrumb

### Review Steps:
- [ ] Pull remote branches `git fetch`
- [ ] Switch branch `git checkout RENO-2717/location-finder-fixes`
- [ ] Spin up branch `npm run dev`
- [ ] Visit http://localhost:3000/locations
- [ ] Search for "Art and Artifacts Division” to see parent-library and *Devision fix
