### PR TITLE
Reno 2791/articles databases fixes

### DIFF
--- a/cypress/tests/articles-databases/articles-databases.test.js
+++ b/cypress/tests/articles-databases/articles-databases.test.js
@@ -3,7 +3,7 @@ import { search } from "./../../support/utils";
 describe("Articles & Databases", () => {
   beforeEach(() => {
     cy.viewport(1024, 768);
-    cy.visit("http://localhost:3000/research/collections/articles-databases");
+    cy.visit("/research/collections/articles-databases");
   });
 
   it("Basic smoke test.", () => {
@@ -121,7 +121,7 @@ describe("Articles & Databases", () => {
   });
 
   it("Most popular links take user to correct page", () => {
-    const pathName = "/research/collections/articles-databases/mango-languages";
+    const pathName = "/research/collections/articles-databases/jstor";
 
     cy.log("Most popular heading should exist.");
     cy.findByRole("heading", {
@@ -131,12 +131,12 @@ describe("Articles & Databases", () => {
 
     cy.log("Click link to goto resource detail page");
     cy.findByRole("link", {
-      name: /mango languages/i,
+      name: /jstor/i,
     }).click();
 
     cy.log("Confirm resource page loads correctly.")
       .findByRole("link", {
-        name: /mango languages/i,
+        name: /jstor/i,
       })
       .should("exist")
       // Check that the url has been updated correctly.

--- a/src/__content/onlineResources.js
+++ b/src/__content/onlineResources.js
@@ -1,6 +1,7 @@
 const onlineResourcesContent = {
-  title: 'Articles & Databases',
-  description: "Explore our collection of hundreds of online resources and databases. Use our free online content to help with your research, whether it's finding a single article, tracing a family tree, learning a new language, or anything in between."
+  title: "Articles & Databases",
+  description:
+    "Explore our collection of hundreds of online resources and databases. Use our free online content to help with your research, whether it's finding a single article, tracing a family tree, learning a new language, or anything in between.",
 };
 
 export default onlineResourcesContent;

--- a/src/components/online-resources/AlphabetNav/AlphabetNav.module.css
+++ b/src/components/online-resources/AlphabetNav/AlphabetNav.module.css
@@ -12,6 +12,7 @@
 
 .letters {
   font-weight: bold;
+  font-size: 18px;
   color: var(--nypl-colors-ui-link-primary);
   background-color: transparent;
   border: none;

--- a/src/components/online-resources/OnlineResourceCard/OnlineResourceCard.js
+++ b/src/components/online-resources/OnlineResourceCard/OnlineResourceCard.js
@@ -10,6 +10,7 @@ import {
   IconNames,
   IconRotationTypes,
   IconSizes,
+  Link,
 } from "@nypl/design-system-react-components";
 import OnlineResourceCardHeading from "./OnlineResourceCardHeading";
 import NextDsLink from "../../shared/Link/NextDsLink";
@@ -48,7 +49,7 @@ function OnlineResourceCard({ item, collapsible, ipInfo }) {
           {items.map((item) => {
             if (item.url) {
               return (
-                <a
+                <Link
                   key={item.id}
                   className={`${s.accessLocation} ${
                     item.id === "all-branch-uuid" && s.disabled
@@ -59,7 +60,7 @@ function OnlineResourceCard({ item, collapsible, ipInfo }) {
                   })}
                 >
                   {item.name}
-                </a>
+                </Link>
               );
             }
           })}

--- a/src/components/online-resources/OnlineResourceCard/OnlineResourceCard.module.css
+++ b/src/components/online-resources/OnlineResourceCard/OnlineResourceCard.module.css
@@ -35,7 +35,7 @@
 .resourceType {
   font-size: 12px;
   font-weight: 700;
-  color: var(--nypl-section-research-primary);
+  color: var(--nypl-colors-section-research-primary);
   text-transform: uppercase;
 }
 

--- a/src/components/online-resources/layouts/PageContainer.js
+++ b/src/components/online-resources/layouts/PageContainer.js
@@ -8,6 +8,8 @@ import Menu from "./../../ds-prototypes/Menu";
 import { ColorVariants } from "@nypl/design-system-react-components";
 // Config
 const { NEXT_PUBLIC_NYPL_DOMAIN } = process.env;
+import { ONLINE_RESOURCES_BASE_PATH } from "./../../../utils/config";
+
 import {
   articlesDatabasesSidebarMenu,
   railMenuContent,
@@ -29,6 +31,10 @@ function PageContainer(props) {
     {
       text: "Collections",
       url: `${NEXT_PUBLIC_NYPL_DOMAIN}/research/collections`,
+    },
+    {
+      text: "Articles & Databases",
+      url: `${NEXT_PUBLIC_NYPL_DOMAIN}${ONLINE_RESOURCES_BASE_PATH}`,
     },
   ];
 

--- a/src/pages/research/collections/articles-databases/[slug].js
+++ b/src/pages/research/collections/articles-databases/[slug].js
@@ -89,8 +89,8 @@ function OnlineResourceSlug() {
       }}
       breadcrumbs={[
         {
-          text: onlineResourcesContent.title,
-          url: `${NEXT_PUBLIC_NYPL_DOMAIN}${ONLINE_RESOURCES_BASE_PATH}`,
+          text: `${data.searchDocument.name}`,
+          url: `${NEXT_PUBLIC_NYPL_DOMAIN}${data.searchDocument.slug}`,
         },
       ]}
       showContentHeader={true}

--- a/src/pages/research/collections/articles-databases/featured/[slug].js
+++ b/src/pages/research/collections/articles-databases/featured/[slug].js
@@ -86,8 +86,8 @@ function FeaturedResourceTopicSlug() {
       }}
       breadcrumbs={[
         {
-          text: onlineResourcesContent.title,
-          url: `${NEXT_PUBLIC_NYPL_DOMAIN}${ONLINE_RESOURCES_BASE_PATH}`,
+          text: resourceTopic.title,
+          url: `${NEXT_PUBLIC_NYPL_DOMAIN}${resourceTopic.slug}`,
         },
       ]}
       showContentHeader={true}

--- a/src/pages/research/collections/articles-databases/find-journals-title-databases.tsx
+++ b/src/pages/research/collections/articles-databases/find-journals-title-databases.tsx
@@ -28,8 +28,8 @@ function OnlineResourcesFindJournalsTitlePage() {
       }}
       breadcrumbs={[
         {
-          text: title,
-          url: `${NEXT_PUBLIC_NYPL_DOMAIN}${ONLINE_RESOURCES_BASE_PATH}`,
+          text: "Scholarly Journals",
+          url: `${NEXT_PUBLIC_NYPL_DOMAIN}${ONLINE_RESOURCES_BASE_PATH}/find-journals-title-databases`,
         },
       ]}
       showContentHeader={false}

--- a/src/pages/research/collections/articles-databases/search.js
+++ b/src/pages/research/collections/articles-databases/search.js
@@ -23,8 +23,7 @@ function OnlineResourcesSearchPage() {
       }}
       breadcrumbs={[
         {
-          text: title,
-          url: `${NEXT_PUBLIC_NYPL_DOMAIN}${ONLINE_RESOURCES_BASE_PATH}`,
+          text: "Search",
         },
       ]}
       showContentHeader={true}

--- a/src/pages/research/collections/articles-databases/verify.js
+++ b/src/pages/research/collections/articles-databases/verify.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import React from "react";
 // Apollo
 import { withApollo } from "../../../../apollo/client/withApollo";
 // Redux
@@ -9,7 +9,6 @@ import VerifyForm from "../../../../components/online-resources/VerifyForm";
 // Utils
 import { ONLINE_RESOURCES_BASE_PATH } from "./../../../../utils/config";
 const { NEXT_PUBLIC_NYPL_DOMAIN } = process.env;
-import onlineResourcesContent from "./../../../../__content/onlineResources";
 
 function OnlineResourcesVerifyPage() {
   return (
@@ -20,7 +19,7 @@ function OnlineResourcesVerifyPage() {
       }}
       breadcrumbs={[
         {
-          text: onlineResourcesContent.title,
+          text: "Login to use this database",
           url: `${NEXT_PUBLIC_NYPL_DOMAIN}${ONLINE_RESOURCES_BASE_PATH}`,
         },
       ]}


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-XXX)
Compare to [Live site]( https://www.nypl.org/research/collections/articles-databases): 
**This PR does the following:**
- Update A-Z Nav font size from 16px to 18px (as per live page)
- Replace <a> tag with <Link> to add underline for Access Locations details (click “Full Details” button to see this)
- Correct color for "CORE RESOURCE" tag. See: `http://localhost:3000/research/collections/articles-databases/search?q=S%26P+Capital+IQ&subject=62&page=1`
- Update breadcrumbs with current page 

### Review Steps:
- [ ] Pull remote branches `git fetch`
- [ ] Switch branch `git checkout RENO-2791/articles-databases-fixes`
- [ ] Spin up branch `npm run dev`
- [ ] Visit http://localhost:3000/research/collections/articles-databases
- [ ] Add `search?q=S%26P+Capital+IQ&subject=62&page=1` to url for "CORE RESOURCES" fix

