### PR TITLE
RENO-2742: Add 404 Pg

### DIFF
--- a/cypress/tests/articles-databases/articles-databases-main.test.js
+++ b/cypress/tests/articles-databases/articles-databases-main.test.js
@@ -1,0 +1,150 @@
+import { search } from "./../../support/utils";
+
+describe("Articles & Databases Tests", () => {
+  beforeEach(() => {
+    cy.viewport(1024, 768);
+    cy.visit("/research/collections/articles-databases");
+  });
+
+  it("Basic smoke test.", () => {
+    cy.log("Page title should exist");
+    cy.findByRole("heading", {
+      level: 1,
+      name: /articles & databases/i,
+    }).should("exist");
+  });
+
+  it("Basic search.", () => {
+    const queryParams = "?q=new+york+times&page=1";
+    const pathName = "/research/collections/articles-databases/search";
+
+    search("new york times", {
+      textboxName: /search articles and databases/i,
+      resultsId: "#search-results",
+    })
+      // Get the first result.
+      .first()
+      .findByRole("link", {
+        name: /new york times \(1980\-present\)/i,
+      })
+      .should("exist")
+      // Check that the url has been updated correctly.
+      .location()
+      .should((loc) => {
+        expect(loc.search).to.eq(queryParams);
+        expect(loc.pathname).to.eq(pathName);
+      });
+  });
+
+  it("Advanced search using autosuggest.", () => {
+    const queryParams = "?q=American+Memory&page=1";
+    const pathName = "/research/collections/articles-databases/search";
+
+    search("american memory", {
+      textboxName: /search articles and databases/i,
+      resultsId: "#search-results",
+      autoSuggest: true,
+      autoSuggestDownArrowCount: 1,
+    })
+      // Get the first result.
+      .first()
+      .findByRole("link", { name: /american memory/i })
+      .should("exist")
+      // Check that the url has been updated correctly.
+      .location()
+      .should((loc) => {
+        expect(loc.search).to.eq(queryParams);
+        expect(loc.pathname).to.eq(pathName);
+      });
+  });
+
+  it("Advanced search using autosuggest and multiselect filter.", () => {
+    const queryParams = "?q=New+York+Times+%281980-present%29&page=1";
+    const pathName = "/research/collections/articles-databases/search";
+
+    cy.log("Open multiselect");
+    cy.findByRole("button", { name: /subjects/i }).click();
+
+    cy.log("Check multiselect item");
+    // { force: true } might be necessary here, expained here:
+    // https://github.com/chakra-ui/chakra-ui/issues/3955
+    cy.findByRole("checkbox", { name: "Art" })
+      .click({ force: true })
+      .should("be.checked");
+
+    search("new york times", {
+      textboxName: /search articles and databases/i,
+      resultsId: "#search-results",
+      autoSuggest: true,
+      autoSuggestDownArrowCount: 2,
+    })
+      // Get the first result.
+      .first()
+      .findByRole("link", {
+        name: /new york times \(1980\-present\)/i,
+      })
+      .should("exist")
+      // Check that the url has been updated correctly.
+      .location()
+      .should((loc) => {
+        expect(loc.search).to.eq(queryParams);
+        expect(loc.pathname).to.eq(pathName);
+      });
+  });
+
+  it("Featured resource links take user to correct page.", () => {
+    const pathName =
+      "/research/collections/articles-databases/featured/homework-help";
+
+    cy.log("Featured resources section should exist.");
+    cy.findByRole("heading", {
+      level: 2,
+      name: /featured resources/i,
+    }).should("exist");
+
+    cy.log("Click link to goto featured resource topic page");
+    cy.findByRole("link", {
+      name: /homework help/i,
+    }).click();
+
+    cy.log("Confirm featured resource topic page loads correctly.");
+    cy.findByRole("heading", {
+      level: 2,
+      name: "Homework Help",
+    })
+      .should("exist")
+      // Check that the url has been updated correctly.
+      .location()
+      .should((loc) => {
+        expect(loc.pathname).to.eq(pathName);
+      });
+  });
+
+  it("Most popular links take user to correct page", () => {
+    const pathName = "/research/collections/articles-databases/jstor";
+
+    cy.log("Most popular heading should exist.");
+    cy.findByRole("heading", {
+      level: 2,
+      name: /most popular/i,
+    }).should("exist");
+
+    cy.log("Click link to goto resource detail page");
+    cy.findByRole("link", {
+      name: /jstor/i,
+    }).click();
+
+    cy.log("Confirm resource page loads correctly.")
+      .findByRole("link", {
+        name: /jstor/i,
+      })
+      .should("exist")
+      // Check that the url has been updated correctly.
+      .location()
+      .should((loc) => {
+        expect(loc.pathname).to.eq(pathName);
+      });
+  });
+
+  it("Alphabet navigation takes user to correct page", () => {});
+});

--- a/cypress/tests/articles-databases/articles-databases.test.js
+++ b/cypress/tests/articles-databases/articles-databases.test.js
@@ -1,150 +1,26 @@
-import { search } from "./../../support/utils";
-
-describe("Articles & Databases", () => {
+describe("Articles & Databases Individual Page Tests", () => {
   beforeEach(() => {
     cy.viewport(1024, 768);
-    cy.visit("/research/collections/articles-databases");
   });
 
-  it("Basic smoke test.", () => {
-    cy.log("Page title should exist");
+  it("Individual page returns 404 message if route doesn't exist in cms.", () => {
+    cy.visit("/research/collections/articles-databases/slug-that-doesnt-exist");
+    cy.log("Check h1 for 404 message.");
     cy.findByRole("heading", {
       level: 1,
-      name: /articles & databases/i,
+      name: /we're sorry\.\.\./i,
     }).should("exist");
   });
 
-  it("Basic search.", () => {
-    const queryParams = "?q=new+york+times&page=1";
-    const pathName = "/research/collections/articles-databases/search";
-
-    search("new york times", {
-      textboxName: /search articles and databases/i,
-      resultsId: "#search-results",
-    })
-      // Get the first result.
-      .first()
-      .findByRole("link", {
-        name: /new york times \(1980\-present\)/i,
-      })
-      .should("exist")
-      // Check that the url has been updated correctly.
-      .location()
-      .should((loc) => {
-        expect(loc.search).to.eq(queryParams);
-        expect(loc.pathname).to.eq(pathName);
-      });
-  });
-
-  it("Advanced search using autosuggest.", () => {
-    const queryParams = "?q=American+Memory&page=1";
-    const pathName = "/research/collections/articles-databases/search";
-
-    search("american memory", {
-      textboxName: /search articles and databases/i,
-      resultsId: "#search-results",
-      autoSuggest: true,
-      autoSuggestDownArrowCount: 1,
-    })
-      // Get the first result.
-      .first()
-      .findByRole("link", { name: /american memory/i })
-      .should("exist")
-      // Check that the url has been updated correctly.
-      .location()
-      .should((loc) => {
-        expect(loc.search).to.eq(queryParams);
-        expect(loc.pathname).to.eq(pathName);
-      });
-  });
-
-  it("Advanced search using autosuggest and multiselect filter.", () => {
-    const queryParams = "?q=New+York+Times+%281980-present%29&page=1";
-    const pathName = "/research/collections/articles-databases/search";
-
-    cy.log("Open multiselect");
-    cy.findByRole("button", { name: /subjects/i }).click();
-
-    cy.log("Check multiselect item");
-    // { force: true } might be necessary here, expained here:
-    // https://github.com/chakra-ui/chakra-ui/issues/3955
-    cy.findByRole("checkbox", { name: "Art" })
-      .click({ force: true })
-      .should("be.checked");
-
-    search("new york times", {
-      textboxName: /search articles and databases/i,
-      resultsId: "#search-results",
-      autoSuggest: true,
-      autoSuggestDownArrowCount: 2,
-    })
-      // Get the first result.
-      .first()
-      .findByRole("link", {
-        name: /new york times \(1980\-present\)/i,
-      })
-      .should("exist")
-      // Check that the url has been updated correctly.
-      .location()
-      .should((loc) => {
-        expect(loc.search).to.eq(queryParams);
-        expect(loc.pathname).to.eq(pathName);
-      });
-  });
-
-  it("Featured resource links take user to correct page.", () => {
-    const pathName =
-      "/research/collections/articles-databases/featured/homework-help";
-
-    cy.log("Featured resources section should exist.");
+  // @TODO Move this to a diff file after tests are more built out.
+  it("Featured resource returns 404 message if route doesn't exist in cms.", () => {
+    cy.visit(
+      "/research/collections/articles-databases/featured/slug-that-doesnt-exist"
+    );
+    cy.log("Check h1 for 404 message.");
     cy.findByRole("heading", {
-      level: 2,
-      name: /featured resources/i,
+      level: 1,
+      name: /we're sorry\.\.\./i,
     }).should("exist");
-
-    cy.log("Click link to goto featured resource topic page");
-    cy.findByRole("link", {
-      name: /homework help/i,
-    }).click();
-
-    cy.log("Confirm featured resource topic page loads correctly.");
-    cy.findByRole("heading", {
-      level: 2,
-      name: "Homework Help",
-    })
-      .should("exist")
-      // Check that the url has been updated correctly.
-      .location()
-      .should((loc) => {
-        expect(loc.pathname).to.eq(pathName);
-      });
   });
-
-  it("Most popular links take user to correct page", () => {
-    const pathName = "/research/collections/articles-databases/jstor";
-
-    cy.log("Most popular heading should exist.");
-    cy.findByRole("heading", {
-      level: 2,
-      name: /most popular/i,
-    }).should("exist");
-
-    cy.log("Click link to goto resource detail page");
-    cy.findByRole("link", {
-      name: /jstor/i,
-    }).click();
-
-    cy.log("Confirm resource page loads correctly.")
-      .findByRole("link", {
-        name: /jstor/i,
-      })
-      .should("exist")
-      // Check that the url has been updated correctly.
-      .location()
-      .should((loc) => {
-        expect(loc.pathname).to.eq(pathName);
-      });
-  });
-
-  it("Alphabet navigation takes user to correct page", () => {});
 });

--- a/cypress/tests/blogs/blog-post.test.js
+++ b/cypress/tests/blogs/blog-post.test.js
@@ -1,0 +1,14 @@
+describe("Blog Post Tests", () => {
+  beforeEach(() => {
+    cy.viewport(1024, 768);
+  });
+
+  it("404 message is returned if route doesn't exist in cms.", () => {
+    cy.visit("/blog/slug-that-doesnt-exist");
+    cy.log("Check h1 for 404 message.");
+    cy.findByRole("heading", {
+      level: 1,
+      name: /we're sorry\.\.\./i,
+    }).should("exist");
+  });
+});

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,0 +1,7 @@
+import Error from "./_error";
+
+function NotFoundPage() {
+  return <Error statusCode={404} />;
+}
+
+export default NotFoundPage;

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -15,25 +15,32 @@ type ErrorProps = {
 };
 
 function Error({ statusCode }: ErrorProps) {
+  const pageTitle = "We're sorry...";
+
   return (
     <PageContainer
       metaTags={{
-        title: "We're Sorry",
+        title: pageTitle,
         description:
           "The page you requested is either unavailable or you need permission to view the content.",
       }}
       breadcrumbs={[
         {
           text: "Home",
-          url: `${NEXT_PUBLIC_NYPL_DOMAIN}`,
+          url: NEXT_PUBLIC_NYPL_DOMAIN as string,
+        },
+        {
+          text: pageTitle,
+          // DS forces us to pass a url here, even tho the last item is never displayed as a link.
+          url: NEXT_PUBLIC_NYPL_DOMAIN as string,
         },
       ]}
-      breadcrumbsColor={ColorVariants.Research}
+      breadcrumbsColor={ColorVariants.WhatsOn}
       wrapperClass="nypl--404"
       contentHeader={null}
       contentPrimary={
         <Box minHeight="400px">
-          <Heading level={HeadingLevels.One}>We're Sorry...</Heading>
+          <Heading level={HeadingLevels.One}>{pageTitle}</Heading>
           <Box>
             <Text>
               The page you requested is either unavailable or you need
@@ -46,7 +53,9 @@ function Error({ statusCode }: ErrorProps) {
               </Link>{" "}
               service.
             </Text>
-            <Box fontWeight="bold">{statusCode}</Box>
+            <Box fontWeight="bold" display="none" visibility="hidden">
+              {statusCode}
+            </Box>
           </Box>
         </Box>
       }

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import {
+  Box,
+  ColorVariants,
+  Heading,
+  HeadingLevels,
+  Link,
+  Text,
+} from "@nypl/design-system-react-components";
+import PageContainer from "../components/shared/layouts/PageContainer";
+const { NEXT_PUBLIC_NYPL_DOMAIN } = process.env;
+
+type ErrorProps = {
+  statusCode: number;
+};
+
+function Error({ statusCode }: ErrorProps) {
+  return (
+    <PageContainer
+      metaTags={{
+        title: "We're Sorry",
+        description:
+          "The page you requested is either unavailable or you need permission to view the content.",
+      }}
+      breadcrumbs={[
+        {
+          text: "Home",
+          url: `${NEXT_PUBLIC_NYPL_DOMAIN}`,
+        },
+      ]}
+      breadcrumbsColor={ColorVariants.Research}
+      wrapperClass="nypl--404"
+      contentHeader={null}
+      contentPrimary={
+        <Box>
+          <Heading level={HeadingLevels.One}>We're Sorry...</Heading>
+          <Box>
+            <Text>
+              The page you requested is either unavailable or you need
+              permission to view the content.
+            </Text>
+            <Text>
+              If you can't find the page you're looking for, please try our{" "}
+              <Link href="https://www.nypl.org/get-help/contact-us">
+                ASK NYPL
+              </Link>{" "}
+              service.
+            </Text>
+            <Box fontWeight="bold">{statusCode}</Box>
+          </Box>
+        </Box>
+      }
+      contentBottom={null}
+    />
+  );
+}
+
+/*Error.getInitialProps = ({ res, err }) => {
+  const statusCode = res ? res.statusCode : err ? err.statusCode : 404;
+  return { statusCode };
+};
+*/
+
+export default Error;

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -32,7 +32,7 @@ function Error({ statusCode }: ErrorProps) {
       wrapperClass="nypl--404"
       contentHeader={null}
       contentPrimary={
-        <Box>
+        <Box minHeight="400px">
           <Heading level={HeadingLevels.One}>We're Sorry...</Heading>
           <Box>
             <Text>
@@ -54,11 +54,5 @@ function Error({ statusCode }: ErrorProps) {
     />
   );
 }
-
-/*Error.getInitialProps = ({ res, err }) => {
-  const statusCode = res ? res.statusCode : err ? err.statusCode : 404;
-  return { statusCode };
-};
-*/
 
 export default Error;

--- a/src/pages/blog/[...slug].tsx
+++ b/src/pages/blog/[...slug].tsx
@@ -47,7 +47,7 @@ function BlogPostPage() {
     return <div>Error.</div>;
   }
 
-  // Loading state,
+  // Loading state.
   if (loading || !data) {
     return (
       <PageContainer

--- a/src/pages/blog/[...slug].tsx
+++ b/src/pages/blog/[...slug].tsx
@@ -1,7 +1,7 @@
 import React from "react";
 // Next
 import { useRouter } from "next/router";
-import ErrorPage from "next/error";
+import Error from "./../_error";
 // Apollo
 import { gql, useQuery } from "@apollo/client";
 import { withApollo } from "../../apollo/client/withApollo";
@@ -39,12 +39,7 @@ function BlogPostPage() {
   // If uuid returns null from useDecoupledRouter, there was no router
   // path match in Drupal, so we return 404 status error component.
   if (!data && uuid === null) {
-    return (
-      <PageContainer
-        showContentHeader={false}
-        contentPrimary={<ErrorPage statusCode={404} />}
-      />
-    );
+    return <Error statusCode={404} />;
   }
 
   // Error state.

--- a/src/pages/research/collections/articles-databases/[slug].js
+++ b/src/pages/research/collections/articles-databases/[slug].js
@@ -12,6 +12,7 @@ import { withRedux } from "./../../../../redux/withRedux";
 import PageContainer from "./../../../../components/online-resources/layouts/PageContainer";
 import OnlineResourceCard from "./../../../../components/online-resources/OnlineResourceCard";
 import { SearchResultsCardSkeletonLoader } from "../../../../components/online-resources/SearchResults/SearchResultsSkeletonLoader";
+import Error from "./../../../_error";
 // Utils
 import { ONLINE_RESOURCES_BASE_PATH } from "./../../../../utils/config";
 const { NEXT_PUBLIC_NYPL_DOMAIN } = process.env;
@@ -60,12 +61,18 @@ function OnlineResourceSlug() {
     },
   });
 
+  // If uuid returns null from useDecoupledRouter, there was no router
+  // path match in Drupal, so we return 404 status error component.
+  if (!data && uuid === null) {
+    return <Error statusCode={404} />;
+  }
+
   // Error state.
   if (error) {
     return <div>Error while loading Online Resource.</div>;
   }
 
-  // Loading state,
+  // Loading state.
   if (loading || !data) {
     return (
       <PageContainer

--- a/src/pages/research/collections/articles-databases/featured/[slug].js
+++ b/src/pages/research/collections/articles-databases/featured/[slug].js
@@ -13,6 +13,7 @@ import {
   SearchResultsSkeletonLoader,
   SearchResultsDetailsSkeletonLoader,
 } from "./../../../../../components/online-resources/SearchResults/SearchResultsSkeletonLoader";
+import Error from "./../../../../_error";
 // Utils
 import { ONLINE_RESOURCES_BASE_PATH } from "./../../../../../utils/config";
 const { NEXT_PUBLIC_NYPL_DOMAIN } = process.env;
@@ -54,7 +55,13 @@ function FeaturedResourceTopicSlug() {
     return <div>Error while loading Online Resource.</div>;
   }
 
-  // Loading state,
+  // If uuid returns null from useDecoupledRouter, there was no router
+  // path match in Drupal, so we return 404 status error component.
+  if (!data && uuid === null) {
+    return <Error statusCode={404} />;
+  }
+
+  // Loading state.
   if (loading || !data) {
     return (
       <PageContainer


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-2742)

**This PR does the following:**
- Adds a basic 404 page to Scout, replacing the NextJS default. This is setup for slug pages which use Drupal CMS for routing, as well as routes that only exist in NextJS.

### Review Steps:
- [ ] A&D Featured Resource: https://pr244-fzo6g2v3sh3ive1tlpeejzuthpwvrifw.tugboat.qa/research/collections/articles-databases/featured/slug-that-doesnt-exist
- [ ] A&D Slug: https://pr244-fzo6g2v3sh3ive1tlpeejzuthpwvrifw.tugboat.qa/research/collections/articles-databases/slug-that-doesnt-exist
- [ ] Blog Slug: https://pr244-fzo6g2v3sh3ive1tlpeejzuthpwvrifw.tugboat.qa/blog/slug-that-doesnt-exist
- [ ] Generic: https://pr244-fzo6g2v3sh3ive1tlpeejzuthpwvrifw.tugboat.qa/page-that-doesnt-exist

