### PR TITLE
RENO-2824: CardList Change Image Alignment to Top

### DIFF
--- a/src/components/shared/ContentComponents/CardList.tsx
+++ b/src/components/shared/ContentComponents/CardList.tsx
@@ -43,7 +43,7 @@ function CardList({ id, type, heading, description, items }: CardListProps) {
               <Box
                 display={{ lg: "flex" }}
                 flexFlow={{ lg: "row" }}
-                alignItems={{ lg: "center" }}
+                alignItems={{ lg: "flex-start" }}
               >
                 {item.image && (
                   <Box


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-2824)

**This PR does the following:**
- Adjusts `CardList` to align items `flex-start` not `center` to position image at top text block.

### Review Steps:
- [ ] Example step one

