### PR TITLE
RENO-2834: Wire up audio heading and desc fields

### DIFF
--- a/src/apollo/client/fragments/blogFields.js
+++ b/src/apollo/client/fragments/blogFields.js
@@ -79,6 +79,8 @@ export const BLOG_FIELDS_FRAGMENT = gql`
         id
         type
         provider
+        heading
+        description
         embedCode
         oembedUrl
       }

--- a/src/apollo/server/resolvers/utils/resolveDrupalParagraphs.ts
+++ b/src/apollo/server/resolvers/utils/resolveDrupalParagraphs.ts
@@ -215,6 +215,8 @@ export default function resolveDrupalParagraphs(
         paragraphComponent = {
           id: item.id,
           type: paragraphTypeName,
+          heading: item.field_ts_heading,
+          description: item.field_tfls_description?.processed,
           provider: audioProvider,
           embedCode: item.field_ers_media_item.field_media_oembed_remote_audio,
           oembedUrl: audioOembedUrl,

--- a/src/apollo/server/type-defs/shared.js
+++ b/src/apollo/server/type-defs/shared.js
@@ -78,6 +78,8 @@ export const typeDefs = gql`
   type AudioEmbed {
     id: ID!
     type: String!
+    heading: String
+    description: String
     provider: String!
     embedCode: String!
     oembedUrl: String!


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-2834)

**This PR does the following:**
- Wires up heading and description to Audio component, which were left off previously by mistake.

### Review Steps:
- [ ] You can view an example here that has an audio component with a heading and description: https://pr248-elb0oyxreuvyxusa9egbm3yxaqtag1kr.tugboat.qa/blog/2022/03/17/qa-blog-post-3822-1127am

