### PR TITLE
RENO-2840: Fix Typo in Channel Filter Pagination

### DIFF
--- a/cypress/tests/blogs/blogs-all.test.js
+++ b/cypress/tests/blogs/blogs-all.test.js
@@ -75,4 +75,24 @@ describe("Blog All pg tests", () => {
       expect(loc.search).to.eq(`?page=3`);
     });
   });
+
+  it("Clicking next link in pagination with filters already selected should goto page 2 and retain filter selection", () => {
+    cy.log("Goto blogs all page");
+    cy.visit("/blog/all?channel=730&page=1");
+
+    cy.log("Find the pagination component");
+    cy.findByRole("navigation", {
+      name: /pagination/i,
+    }).within(() => {
+      cy.log("Click next page");
+      cy.findByRole("link", {
+        name: /next page/i,
+      }).click();
+    });
+
+    cy.log("Filter id is retained and pagination should be on page 2");
+    cy.location().should((loc) => {
+      expect(loc.search).to.eq(`?channel=730&page=2`);
+    });
+  });
 });

--- a/src/components/blogs/BlogsContainer/BlogsContainer.tsx
+++ b/src/components/blogs/BlogsContainer/BlogsContainer.tsx
@@ -137,7 +137,7 @@ function BlogsContainer({
       query: {
         // @TODO do this better.
         ...(router.query.channel && {
-          alpha: router.query.channel,
+          channel: router.query.channel,
         }),
         ...(router.query.subject && {
           subject: router.query.subject,


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-2840)

**This PR does the following:**
- Fixes bug where channel filter does not get updated properly when selecting next pg. 
- Adds test for this scenario

**To reproduce bug**
- go here: https://qa-www.nypl.org/blog/all?channel=730&page=1
- Click "next" pg link in pagination 
- Query parms change to `?alpha=730&page=2` 

### Review Steps:
- [ ] Go here: https://pr250-sqwaqqq5s0q3ouy5xp3nyrp29ua4geyd.tugboat.qa/blog/all?channel=730&page=1
- [ ] Click "next" pg link in pagination
- [ ] Query params should now correctly change to `?channel=730&page=2`

