### PR TITLE
RENO-3071: Connect Updates Section with Drupal Content

### DIFF
--- a/src/apollo/server/resolvers/homePageResolver.js
+++ b/src/apollo/server/resolvers/homePageResolver.js
@@ -21,6 +21,8 @@ const homePageResolver = {
         "field_hp_section_4.field_erm_hp_cards.field_ers_image.field_media_image",
         "field_hp_section_7.field_erm_hp_cards",
         "field_hp_section_7.field_erm_hp_cards.field_ers_image.field_media_image",
+        "field_hp_section_8.field_erm_hp_cards",
+        "field_hp_section_8.field_erm_hp_cards.field_ers_image.field_media_image",
       ];
       const isPreview = args.preview ? true : false;
       const apiPath = getIndividualResourceJsonApiPath(
@@ -190,14 +192,26 @@ const homePageResolver = {
     sectionSeven: (homePage, _, __, info) => {
       const resolveInfo = parseResolveInfo(info);
       const typesInQuery = Object.keys(resolveInfo.fieldsByTypeName);
-      const sectionFour =
+      const sectionSeven =
         homePage.field_hp_section_7.data?.length === 0
           ? null
           : resolveDrupalParagraphs(
               [homePage.field_hp_section_7],
               typesInQuery
             );
-      return sectionFour;
+      return sectionSeven;
+    },
+    sectionEight: (homePage, _, __, info) => {
+      const resolveInfo = parseResolveInfo(info);
+      const typesInQuery = Object.keys(resolveInfo.fieldsByTypeName);
+      const sectionEight =
+        homePage.field_hp_section_8.data?.length === 0
+          ? null
+          : resolveDrupalParagraphs(
+              [homePage.field_hp_section_8],
+              typesInQuery
+            );
+      return sectionEight;
     },
   },
   SectionOne: {
@@ -221,6 +235,11 @@ const homePageResolver = {
     },
   },
   SectionSeven: {
+    __resolveType: (object, _, __) => {
+      return resolveParagraphTypes(object.type);
+    },
+  },
+  SectionEight: {
     __resolveType: (object, _, __) => {
       return resolveParagraphTypes(object.type);
     },

--- a/src/apollo/server/type-defs/homepage.js
+++ b/src/apollo/server/type-defs/homepage.js
@@ -12,6 +12,7 @@ export const typeDefs = gql`
     sectionThree: [SectionThree]
     sectionFour: [SectionFour]
     sectionSeven: [SectionSeven]
+    sectionEight: [SectionEight]
   }
 
   union SectionOne = HomePageHeroComponent
@@ -19,6 +20,7 @@ export const typeDefs = gql`
   union SectionThree = HomePageEventsComponent | HomePageCardGridComponent
   union SectionFour = HomePageCardGridComponent | HomePageEventsComponent
   union SectionSeven = HomePageCardGridComponent
+  union SectionEight = HomePageCardGridComponent
 
   # Home page content components (Drupal paragraphs).
   type HomePageHeroComponent {

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -125,6 +125,38 @@ export const HOMEPAGE_QUERY = gql`
           }
         }
       }
+      sectionEight {
+        __typename
+        ... on HomePageCardGridComponent {
+          id
+          type
+          heading
+          link
+          gridVariant
+          items {
+            id
+            title
+            description
+            url
+            image {
+              id
+              uri
+              alt
+              width
+              height
+              transformations {
+                id
+                label
+                uri
+              }
+            }
+          }
+          seeMore {
+            text
+            link
+          }
+        }
+      }
     }
   }
 `;
@@ -168,6 +200,7 @@ function HomePage() {
   const homePageDataSectionThree = data.homePage.sectionThree[0];
   const homePageDataSectionFour = data.homePage.sectionFour[0];
   const homePageDataSectionSeven = data.homePage.sectionSeven[0];
+  const homePageDataSectionEight = data.homePage.sectionEight[0];
 
   return (
     <>
@@ -215,6 +248,17 @@ function HomePage() {
                 cardVariant="blog-card"
                 seeMore={homePageDataSectionSeven.seeMore}
               />
+              {/* Updates */}
+              <CardGrid
+                title={homePageDataSectionEight.heading}
+                link={homePageDataSectionEight.link}
+                items={homePageDataSectionEight.items}
+                variant={homePageDataSectionEight.gridVariant}
+                hoverStyle={true}
+                seeMore={homePageDataSectionEight.seeMore}
+                cardVariant="updates-card"
+                size="sm"
+              />
               {/* <CardGrid
                 title={discoverContent.title}
                 link={discoverContent.link}
@@ -239,8 +283,8 @@ function HomePage() {
                 hoverStyle={true}
                 variant="row-grid"
                 cardVariant="blog-card"
-              />
-              <CardGrid
+              /> 
+                <CardGrid
                 title={updatesContent.title}
                 link={updatesContent.link}
                 items={updatesContent.items}


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-3071)

**This PR does the following:**
- Updates drupal Resolver for Updates section (section 8)
- Updates QraphQL query with Updates section
- Replaces mock content for Updates section with data from Drupal

### Review Steps:
- [ ] Pull in branch `git fetch`
- [ ] Switch to relevant branch `git checkout RENO-3071/connect-updates-with-drupal`
- [ ]  Spin up the homepage locally `npm run dev`
- [ ] Compare [localhost](http://localhost:3000/home) "Updates" Section content with [Drupal content of Section 8](https://pr974-nypl1.pantheonsite.io/node/10951/edit)
- [ ] Compare layout and style from [localhost](http://localhost:3000/home) with [Live homepage](http://nypl.org/)


