### PR TITLE
Reno 3095/fix events collection mobile card style

### DIFF
--- a/src/components/home-v1/EventCollection/EventCollection.tsx
+++ b/src/components/home-v1/EventCollection/EventCollection.tsx
@@ -158,7 +158,7 @@ export default function EventCollection({
             }
             if (featuredEvent) {
               return (
-                <Box as="li" mb={8} key={`${eventCategory}-featured-event-key`}>
+                <Box as="li" mb={4} key={`${eventCategory}-featured-event-key`}>
                   <Heading
                     as="h3"
                     fontFamily="Kievit-Medium"

--- a/src/components/home-v1/EventCollection/EventCollection.tsx
+++ b/src/components/home-v1/EventCollection/EventCollection.tsx
@@ -170,11 +170,7 @@ export default function EventCollection({
                   >
                     {eventCategoryLabel(eventCategory)}
                   </Heading>
-                  <EventCard
-                    {...featuredEvent}
-                    variant="event-card"
-                    size="lg"
-                  />
+                  <EventCard {...featuredEvent} variant="event-card" />
                 </Box>
               );
             }

--- a/src/components/home-v1/EventCollection/EventCollectionTabPanelContent.tsx
+++ b/src/components/home-v1/EventCollection/EventCollectionTabPanelContent.tsx
@@ -29,8 +29,8 @@ export default function EventCollectionTabPanelContent({
         xl: "1fr 1fr",
       }}
       templateRows={{ base: "1fr", lg: "min-content min-content min-content" }}
-      columnGap={{ base: 6, lg: 7 }}
-      gap={{ base: 6, lg: 0 }}
+      columnGap={{ base: 4, lg: 7 }}
+      gap={{ base: 4, lg: 0 }}
       listStyleType="none"
     >
       {/* Desktop */}

--- a/src/components/home-v1/EventCollection/EventCollectionTabPanelContent.tsx
+++ b/src/components/home-v1/EventCollection/EventCollectionTabPanelContent.tsx
@@ -33,6 +33,7 @@ export default function EventCollectionTabPanelContent({
       gap={{ base: 6, lg: 0 }}
       listStyleType="none"
     >
+      {/* Desktop */}
       <GridItem
         id={`${id}__featured-item`}
         as="li"
@@ -49,7 +50,6 @@ export default function EventCollectionTabPanelContent({
           />
         )}
       </GridItem>
-      {/* Desktop */}
       {events &&
         // Skip featured event item
         events.slice(1, 4).map((event, i) => {
@@ -60,7 +60,7 @@ export default function EventCollectionTabPanelContent({
               display={{ base: "none", lg: "block" }}
               colStart={2}
             >
-              <EventCard {...event} variant="event-card" size="sm" />
+              <EventCard {...event} variant="event-card" />
             </GridItem>
           );
         })}
@@ -73,7 +73,7 @@ export default function EventCollectionTabPanelContent({
               key={`event-item-key-${i}`}
               display={{ base: "none", md: "block", lg: "none" }}
             >
-              <EventCard {...event} variant="event-card" size="sm" />
+              <EventCard {...event} variant="event-card" />
             </GridItem>
           );
         })}

--- a/src/components/home-v1/theme/event.ts
+++ b/src/components/home-v1/theme/event.ts
@@ -16,7 +16,7 @@ const Event: ComponentStyleConfig = {
     // Title
     h3: {
       fontFamily: "Kievit-Medium",
-      fontSize: { base: "lg", md: "xl" },
+      fontSize: { base: "lg", lg: "xl" },
       fontWeight: "normal",
       lineHeight: "none",
       px: 0,
@@ -38,14 +38,11 @@ const Event: ComponentStyleConfig = {
     },
     // Location
     p: { fontSize: "sm", lineHeight: "none", px: 0 },
+    // Image
     img: { w: "full" },
   },
   // Heading sizes
   sizes: {
-    sm: {
-      h3: { fontSize: "lg" },
-    },
-    lg: { h3: { fontSize: "2xl" } },
     xl: { h3: { fontSize: "26px" } },
   },
   variants: {
@@ -57,7 +54,7 @@ const Event: ComponentStyleConfig = {
     },
     "event-card": {
       gridTemplateColumns: { base: "4fr 9fr", md: "5fr 11fr", lg: "1fr 3fr" },
-      gridGap: { base: 9, md: 6, lg: 4 },
+      gridGap: { base: 6, lg: 4 },
       mb: { base: 0, lg: 7 },
       h3: {
         lineHeight: "22px",
@@ -65,14 +62,13 @@ const Event: ComponentStyleConfig = {
       },
       span: {
         mt: 1.5,
+        fontSize: { base: "xs", lg: "sm" },
       },
       p: {
         fontSize: "xs",
       },
     },
   },
-  // The default `size` value
-  defaultProps: { size: "lg" },
 };
 
 export default Event;


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-3095)

**This PR does the following:**
- Fixes font size of event card for mobile and tablet view
- Adjusts spacing between card according to live home page

### Review Steps:
- [ ] Pull in latest branch `git fetch`
- [ ] Switch to relevant branch `git checkout RENO-3095/fix-events-collection-mobile-card-style`
- [ ] Build site locally `npm run build && npm start`
- [ ] Compare **What's On** section [Local Homepage](http://localhost:3000) with [Live Homepage](http://nypl.org)

### Front End Review Steps:
- [ ] View [Homepage](http://localhost:3000/)
