### PR TITLE
RENO-3081: Update Press Pages With getServerSideProps

### DIFF
--- a/src/apollo/server/resolvers/pressReleaseResolver.js
+++ b/src/apollo/server/resolvers/pressReleaseResolver.js
@@ -26,7 +26,7 @@ const pressReleaseResolver = {
         "node",
         "press_release",
         includedFields,
-        null,
+        args.filter,
         args.sort,
         pagination
       );

--- a/src/apollo/server/type-defs/press.js
+++ b/src/apollo/server/type-defs/press.js
@@ -19,11 +19,16 @@ export const typeDefs = gql`
 
   union PressReleaseMainContent = Text | TextWithImage | ImageComponent
 
+  input PressFilter {
+    status: QueryFilterItemBoolean
+  }
+
   extend type Query {
     allPressReleases(
       limit: Int
       pageNumber: Int
       sort: Sort
+      filter: PressFilter
     ): PressReleaseConnection
     pressRelease(id: String, revisionId: String, preview: Boolean): PressRelease
   }

--- a/src/apollo/withApollo/apollo.ts
+++ b/src/apollo/withApollo/apollo.ts
@@ -8,6 +8,12 @@ import getDataSources from "./../server/datasources/getDataSources";
 import { schema } from "./../server/schema";
 const { NEXT_PUBLIC_GRAPHQL_API } = process.env;
 
+// Add type for the apollo page props
+// @see https://github.com/vercel/next.js/discussions/16522
+export interface ApolloPageProps {
+  initialApolloState: NormalizedCacheObject;
+}
+
 let apolloClient: ApolloClient<NormalizedCacheObject> | undefined;
 
 function createIsomorphLink() {

--- a/src/components/press-releases/PressRelease/PressRelease.tsx
+++ b/src/components/press-releases/PressRelease/PressRelease.tsx
@@ -43,8 +43,7 @@ function PressRelease({ pressRelease }: PressReleaseProps) {
         <Heading level="one" size="secondary" text={pressRelease.title} />
         {description !== null && (
           <Box
-            // @TODO This no longer works, lets fix this soon.
-            //isItalic={true}
+            as="i"
             mb="s"
             fontSize={"1"}
             dangerouslySetInnerHTML={{ __html: description }}

--- a/src/components/press-releases/PressReleaseCollection/PressReleaseCollection.tsx
+++ b/src/components/press-releases/PressReleaseCollection/PressReleaseCollection.tsx
@@ -12,10 +12,20 @@ import { PressReleaseItem } from "./PressReleaseCardType";
 // Next
 import { useRouter } from "next/router";
 
-const ALL_PRESS_RELEASES_QUERY = gql`
+export const ALL_PRESS_RELEASES_QUERY = gql`
   ${PRESS_FIELDS_FRAGMENT}
-  query AllPressReleases($limit: Int, $pageNumber: Int, $sort: Sort) {
-    allPressReleases(limit: $limit, pageNumber: $pageNumber, sort: $sort) {
+  query AllPressReleases(
+    $limit: Int
+    $pageNumber: Int
+    $sort: Sort
+    $filter: PressFilter
+  ) {
+    allPressReleases(
+      limit: $limit
+      pageNumber: $pageNumber
+      sort: $sort
+      filter: $filter
+    ) {
       items {
         ...PressFields
       }
@@ -53,6 +63,7 @@ function PressReleaseCollection({
       limit: limit ? limit : null,
       pageNumber: currentPage ? currentPage : 1,
       sort: sort ? sort : null,
+      filter: { status: { fieldName: "status", operator: "=", value: true } },
     },
   });
 

--- a/src/components/press-releases/PressReleaseCollection/PressReleaseCollection.tsx
+++ b/src/components/press-releases/PressReleaseCollection/PressReleaseCollection.tsx
@@ -44,6 +44,7 @@ interface PressReleaseCollectionProps {
   mediaContacts: string;
   limit: number;
   sort: any;
+  status: boolean;
 }
 
 function PressReleaseCollection({
@@ -52,6 +53,7 @@ function PressReleaseCollection({
   mediaContacts,
   limit,
   sort,
+  status,
 }: PressReleaseCollectionProps) {
   const router = useRouter();
   const currentPage = router.query.page
@@ -63,7 +65,7 @@ function PressReleaseCollection({
       limit: limit ? limit : null,
       pageNumber: currentPage ? currentPage : 1,
       sort: sort ? sort : null,
-      filter: { status: { fieldName: "status", operator: "=", value: true } },
+      filter: { status: { fieldName: "status", operator: "=", value: status } },
     },
   });
 

--- a/src/components/press-releases/PressReleaseCollection/index.ts
+++ b/src/components/press-releases/PressReleaseCollection/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./PressReleaseCollection";
+export { default, ALL_PRESS_RELEASES_QUERY } from "./PressReleaseCollection";

--- a/src/pages/press/index.tsx
+++ b/src/pages/press/index.tsx
@@ -1,9 +1,13 @@
 import React from "react";
+import { GetStaticProps } from "next";
 // Apollo
-import { withApollo } from "../../apollo/client/withApollo";
+import withApollo from "./../../apollo/withApollo";
+import { initializeApollo } from "./../../apollo/withApollo/apollo";
 // Components
 import PageContainer from "../../components/press-releases/layouts/PageContainer";
-import PressReleaseCollection from "../../components/press-releases/PressReleaseCollection";
+import PressReleaseCollection, {
+  ALL_PRESS_RELEASES_QUERY,
+} from "../../components/press-releases/PressReleaseCollection";
 // Content
 import pressContent from "../../__content/press";
 
@@ -31,7 +35,25 @@ function PressMainPage() {
   );
 }
 
-export default withApollo(PressMainPage, {
-  ssr: true,
-  redirects: false,
-});
+export const getStaticProps: GetStaticProps = async () => {
+  const apolloClient = initializeApollo();
+
+  await apolloClient.query({
+    query: ALL_PRESS_RELEASES_QUERY,
+    variables: {
+      limit: 10,
+      pageNumber: 1,
+      sort: { field: "created", direction: "DESC" },
+      filter: { status: { fieldName: "status", operator: "=", value: true } },
+    },
+  });
+  return {
+    props: {
+      initializeApollo: apolloClient.cache.extract(),
+    },
+    // 10 mins.
+    revalidate: 600,
+  };
+};
+
+export default withApollo(PressMainPage);

--- a/src/pages/press/index.tsx
+++ b/src/pages/press/index.tsx
@@ -28,6 +28,7 @@ function PressMainPage() {
             mediaContacts={mediaContacts.bodyText}
             limit={10}
             sort={{ field: "created", direction: "DESC" }}
+            status={true}
           />
         </>
       }
@@ -49,7 +50,7 @@ export const getStaticProps: GetStaticProps = async () => {
   });
   return {
     props: {
-      initializeApollo: apolloClient.cache.extract(),
+      initialApolloState: apolloClient.cache.extract(),
     },
     // 10 mins.
     revalidate: 600,

--- a/src/pages/press/index.tsx
+++ b/src/pages/press/index.tsx
@@ -1,8 +1,11 @@
 import React from "react";
-import { GetStaticProps } from "next";
+import { GetServerSideProps } from "next";
 // Apollo
 import withApollo from "./../../apollo/withApollo";
-import { initializeApollo } from "./../../apollo/withApollo/apollo";
+import {
+  initializeApollo,
+  ApolloPageProps,
+} from "./../../apollo/withApollo/apollo";
 // Components
 import PageContainer from "../../components/press-releases/layouts/PageContainer";
 import PressReleaseCollection, {
@@ -13,6 +16,7 @@ import pressContent from "../../__content/press";
 
 function PressMainPage() {
   const { meta, mediaContacts } = pressContent;
+
   return (
     <PageContainer
       metaTags={{
@@ -36,7 +40,9 @@ function PressMainPage() {
   );
 }
 
-export const getStaticProps: GetStaticProps = async () => {
+export const getServerSideProps: GetServerSideProps<
+  ApolloPageProps
+> = async () => {
   const apolloClient = initializeApollo();
 
   await apolloClient.query({
@@ -48,12 +54,11 @@ export const getStaticProps: GetStaticProps = async () => {
       filter: { status: { fieldName: "status", operator: "=", value: true } },
     },
   });
+
   return {
     props: {
       initialApolloState: apolloClient.cache.extract(),
     },
-    // 10 mins.
-    revalidate: 600,
   };
 };
 


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-3081)

**This PR does the following:**
- Updates press page index.tsx file with next's getStaticProps 
- Updates query in PressReleaseCollection.tsx to filter by status
- Creates PressFilter type for query
- Updates [...slug].tsx with next's getServerSideProps

### Review Steps:
- [ ] Pull in latest branch `git fetch`
- [ ] Switch to relevant branch `git checkout RENO-3081/update-press-pages-with-getServerSideProps`
- [ ] Build site locally `npm run build && npm start`
- [ ] Open [Press Release Page](http://localhost/press)
- [ ] Open dev tools in browser (press option + command + J)
- [ ] Navigate to **Network** tab in dev tools
- [ ] Click on Filter **Fetch/XHR**
- [ ] Upon refreshing the page, there should be no **graphql** api call listed 

### Front End Review Steps:
- [ ] View [Press Release Page](http://localhost:3000/press)
