### PR TITLE
RENO-3153: Update HomePageEvent to Use Heading Field

### DIFF
--- a/src/apollo/server/resolvers/homePageResolver.js
+++ b/src/apollo/server/resolvers/homePageResolver.js
@@ -314,7 +314,7 @@ const homePageResolver = {
   },
   HomePageEvent: {
     id: (homePageEvent) => homePageEvent.id,
-    title: (homePageEvent) => homePageEvent.title,
+    title: (homePageEvent) => homePageEvent.field_ts_heading,
     image: (homePageEvent) => {
       const image =
         homePageEvent.field_ers_media_image.data === null


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-3153)

**This PR does the following:**
- Updates Home page event to use `field_ts_heading` instead of `title`

### Review Steps:
- [ ] Pull in latest code
- [ ] Start app in production mode
- [ ] Check that heading field is being used for Event heading.


