### PR TITLE
RENO-3166: Hide spotlight and event collections if no items

### DIFF
--- a/src/components/home-v1/EventCollection/EventCollection.tsx
+++ b/src/components/home-v1/EventCollection/EventCollection.tsx
@@ -136,6 +136,11 @@ export default function EventCollection({
     }
   };
 
+  // Don't display the section if there's no items.
+  if (data.homePageEventCollection.items.length === 0) {
+    return null;
+  }
+
   return (
     <ComponentWrapper
       id={id}

--- a/src/components/home-v1/Spotlight/Spotlight.tsx
+++ b/src/components/home-v1/Spotlight/Spotlight.tsx
@@ -88,6 +88,11 @@ export default function Spotlight({
     return <div>Loading ...</div>;
   }
 
+  // Don't display the section if there's no items.
+  if (data.homePageSpotlightCollection.items.length === 0) {
+    return null;
+  }
+
   return (
     <CardGrid
       id={id}


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-3166)

**This PR does the following:**
- Hide "Spotlight" and "What's On" sections if no items.
