### PR TITLE
RENO-3170: Update Slideshow To Cap Items Array

### DIFF
--- a/src/components/home-v1/Slideshow/Slideshow.tsx
+++ b/src/components/home-v1/Slideshow/Slideshow.tsx
@@ -18,8 +18,15 @@ interface SlideshowProps {
 }
 
 function Slideshow({ id, title, link, items, seeMore }: SlideshowProps) {
+  let itemsSlice: SlideshowItem[];
+  // Ensure items array is never longer than 10 items
+  if (items.length > 10) {
+    itemsSlice = items.slice(0, 10);
+  } else {
+    itemsSlice = items.slice();
+  }
   const { currentSlide, prevSlide, nextSlide, slideshowStyle } =
-    useSlideshowStyles(items.length, 15.7);
+    useSlideshowStyles(itemsSlice.length, Math.floor(100 / itemsSlice.length));
   return (
     <ComponentWrapper
       id={id}
@@ -40,7 +47,7 @@ function Slideshow({ id, title, link, items, seeMore }: SlideshowProps) {
           <SlideshowButton direction={"prev"} prevSlide={prevSlide} />
         )}
         <SlideshowContainer
-          items={items}
+          items={itemsSlice}
           slideshowStyle={slideshowStyle}
           currentSlide={currentSlide}
           nextSlide={nextSlide}
@@ -50,7 +57,9 @@ function Slideshow({ id, title, link, items, seeMore }: SlideshowProps) {
         <SlideshowButton
           direction={"next"}
           nextSlide={nextSlide}
-          visibility={currentSlide !== items.length - 1 ? "visibile" : "hidden"}
+          visibility={
+            currentSlide !== itemsSlice.length - 1 ? "visibile" : "hidden"
+          }
         />
       </Box>
     </ComponentWrapper>

--- a/src/components/home-v1/Slideshow/Slideshow.tsx
+++ b/src/components/home-v1/Slideshow/Slideshow.tsx
@@ -18,15 +18,11 @@ interface SlideshowProps {
 }
 
 function Slideshow({ id, title, link, items, seeMore }: SlideshowProps) {
-  let itemsSlice: SlideshowItem[];
   // Ensure items array is never longer than 10 items
-  if (items.length > 10) {
-    itemsSlice = items.slice(0, 10);
-  } else {
-    itemsSlice = items.slice();
-  }
+  const finalItems: SlideshowItem[] = items.slice(0, 10);
+
   const { currentSlide, prevSlide, nextSlide, slideshowStyle } =
-    useSlideshowStyles(itemsSlice.length, Math.floor(100 / itemsSlice.length));
+    useSlideshowStyles(finalItems.length, Math.floor(100 / finalItems.length));
   return (
     <ComponentWrapper
       id={id}
@@ -47,7 +43,7 @@ function Slideshow({ id, title, link, items, seeMore }: SlideshowProps) {
           <SlideshowButton direction={"prev"} prevSlide={prevSlide} />
         )}
         <SlideshowContainer
-          items={itemsSlice}
+          items={finalItems}
           slideshowStyle={slideshowStyle}
           currentSlide={currentSlide}
           nextSlide={nextSlide}
@@ -58,7 +54,7 @@ function Slideshow({ id, title, link, items, seeMore }: SlideshowProps) {
           direction={"next"}
           nextSlide={nextSlide}
           visibility={
-            currentSlide !== itemsSlice.length - 1 ? "visibile" : "hidden"
+            currentSlide !== finalItems.length - 1 ? "visibile" : "hidden"
           }
         />
       </Box>

--- a/src/components/home-v1/Slideshow/Slideshow.tsx
+++ b/src/components/home-v1/Slideshow/Slideshow.tsx
@@ -18,11 +18,12 @@ interface SlideshowProps {
 }
 
 function Slideshow({ id, title, link, items, seeMore }: SlideshowProps) {
-  // Ensure items array is never longer than 10 items
+  // Ensure items array is never longer than 10 items.
   const finalItems: SlideshowItem[] = items.slice(0, 10);
 
   const { currentSlide, prevSlide, nextSlide, slideshowStyle } =
     useSlideshowStyles(finalItems.length, Math.floor(100 / finalItems.length));
+
   return (
     <ComponentWrapper
       id={id}

--- a/src/components/home-v1/Slideshow/SlideshowContainer.tsx
+++ b/src/components/home-v1/Slideshow/SlideshowContainer.tsx
@@ -29,6 +29,7 @@ function SlideshowContainer({
       prevSlide();
     }
   };
+
   return (
     <Box w="full" overflow="hidden">
       <Grid


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-3170)

**This PR does the following:**
- Adds a check for the length of the incoming items in Slideshow.tsx
- Crops the incoming items at 10 items if needed

### Review Steps:
- [ ] Pull in branch `git fetch`
- [ ] Switch to relevant brach `git checkout RENO-3170/slideshow-item-list`
- [ ] Start a local build `npm run build && npm start`
- [ ] Confirm tests are passing `npm test`

### Front End Review Steps:
- [ ] Visit [Drupal Mutlidev](https://pr974-nypl1.pantheonsite.io/user/login?bypass)
- [ ] Check that there are 11 slides added to the **New & Noteworthy** section
- [ ] View [Local Homepage](http://localhost:3000/)
- [ ] Only 10 slides are rendered in the **New & Noteworthy** section
- [ ] Confirm style and layout are in line with [Live Homepage](http://nypl.org/)
