### PR TITLE
RENO-3087: Wire Up Subtitle and Meta Description Fields to individual PressRelease

### DIFF
--- a/src/apollo/client/fragments/pressFields.js
+++ b/src/apollo/client/fragments/pressFields.js
@@ -4,7 +4,7 @@ export const PRESS_FIELDS_FRAGMENT = gql`
   fragment PressFields on PressRelease {
     id
     title
-    subtitle
+    subTitle
     description
     slug
     date

--- a/src/apollo/client/fragments/pressFields.js
+++ b/src/apollo/client/fragments/pressFields.js
@@ -4,6 +4,7 @@ export const PRESS_FIELDS_FRAGMENT = gql`
   fragment PressFields on PressRelease {
     id
     title
+    subtitle
     description
     slug
     date

--- a/src/apollo/server/resolvers/pressReleaseResolver.js
+++ b/src/apollo/server/resolvers/pressReleaseResolver.js
@@ -67,6 +67,7 @@ const pressReleaseResolver = {
   PressRelease: {
     id: (pressRelease) => pressRelease.id,
     title: (pressRelease) => pressRelease.title,
+    subtitle: (pressRelease) => pressRelease.field_tfls_subtitle?.processed,
     description: (pressRelease) =>
       pressRelease.field_tfls_summary_description?.processed,
     slug: (pressRelease) => pressRelease.path.alias,

--- a/src/apollo/server/resolvers/pressReleaseResolver.js
+++ b/src/apollo/server/resolvers/pressReleaseResolver.js
@@ -67,7 +67,7 @@ const pressReleaseResolver = {
   PressRelease: {
     id: (pressRelease) => pressRelease.id,
     title: (pressRelease) => pressRelease.title,
-    subtitle: (pressRelease) => pressRelease.field_tfls_subtitle?.processed,
+    subTitle: (pressRelease) => pressRelease.field_tfls_subTitle?.processed,
     description: (pressRelease) =>
       pressRelease.field_tfls_summary_description?.processed,
     slug: (pressRelease) => pressRelease.path.alias,

--- a/src/apollo/server/type-defs/press.js
+++ b/src/apollo/server/type-defs/press.js
@@ -4,6 +4,7 @@ export const typeDefs = gql`
   type PressRelease {
     id: ID!
     title: String!
+    subtitle: String
     description: String
     image: Image
     slug: String!

--- a/src/apollo/server/type-defs/press.js
+++ b/src/apollo/server/type-defs/press.js
@@ -4,7 +4,7 @@ export const typeDefs = gql`
   type PressRelease {
     id: ID!
     title: String!
-    subtitle: String
+    subTitle: String
     description: String
     image: Image
     slug: String!

--- a/src/components/press-releases/PressRelease/PressRelease.tsx
+++ b/src/components/press-releases/PressRelease/PressRelease.tsx
@@ -12,9 +12,10 @@ interface PressReleaseProps {
 }
 
 function PressRelease({ pressRelease }: PressReleaseProps) {
-  // Ensure line breaks from Drupal are respected. @QUESTION: is still needed fro subtitles?
-  const subtitle = pressRelease.subtitle
-    ? pressRelease.subtitle.replace(/\n/g, "<br/>")
+  // Ensure line breaks from Drupal are respected.
+  // @TODO: Determine if this is still needed for subTitle values.
+  const subTitle = pressRelease.subTitle
+    ? pressRelease.subTitle.replace(/\n/g, "<br/>")
     : null;
 
   const { about } = pressContent;
@@ -26,12 +27,12 @@ function PressRelease({ pressRelease }: PressReleaseProps) {
         <Heading level="one" size="secondary">
           {pressRelease.title}
         </Heading>
-        {subtitle !== null && (
+        {subTitle !== null && (
           <Box
             as="i"
             mb="s"
             fontSize={"1"}
-            dangerouslySetInnerHTML={{ __html: subtitle }}
+            dangerouslySetInnerHTML={{ __html: subTitle }}
           />
         )}
       </Box>

--- a/src/components/press-releases/PressRelease/PressRelease.tsx
+++ b/src/components/press-releases/PressRelease/PressRelease.tsx
@@ -12,9 +12,9 @@ interface PressReleaseProps {
 }
 
 function PressRelease({ pressRelease }: PressReleaseProps) {
-  // Ensure line breaks from Drupal are respected.
-  const description = pressRelease.description
-    ? pressRelease.description.replace(/\n/g, "<br/>")
+  // Ensure line breaks from Drupal are respected. @QUESTION: is still needed fro subtitles?
+  const subtitle = pressRelease.subtitle
+    ? pressRelease.subtitle.replace(/\n/g, "<br/>")
     : null;
 
   const { about } = pressContent;
@@ -26,12 +26,12 @@ function PressRelease({ pressRelease }: PressReleaseProps) {
         <Heading level="one" size="secondary">
           {pressRelease.title}
         </Heading>
-        {description !== null && (
+        {subtitle !== null && (
           <Box
             as="i"
             mb="s"
             fontSize={"1"}
-            dangerouslySetInnerHTML={{ __html: description }}
+            dangerouslySetInnerHTML={{ __html: subtitle }}
           />
         )}
         <Box mb="s">{pressRelease.date}</Box>


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-3087)

**This PR does the following:**
- Adds `field_tfls_subtitle` to the pressReleaseResolver
- Adds subtitle to the press type
- Adds subtitle to the pressFields
- Replaces description with subtitle in PressRelease.tsx

### Review Steps:
- [ ] Pull in branch `git fetch`
- [ ] Switch to relevant brach `git checkout RENO-3087/wire-up-subtitle-and-meta-field`
- [ ] Start a local build `npm run build && npm start`
- [ ] Confirm tests are passing `npm test`

### Front End Review Steps:
- [ ] View [Local Homepage](http://localhost:3000/press/nypl-celebrates-beloved-storyteller-and-library-lion-toni-morrison-observation-banned-books)
- [ ] Check on [Drupal MultiDev](https://pr952-nypl1.pantheonsite.io/node/14619/edit?destination=/admin/content) that the **Subtitle** field is rendered underneath the Title on the Press Release page
- [ ] Inspect the Element to see that the `meta description` holds the **Metadata summery** content of the  [Drupal MultiDev](https://pr952-nypl1.pantheonsite.io/node/14619/edit?destination=/admin/content)
