### PR TITLE
RENO-3301: Setup Additional AWS environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ cache:
     - node_modules
 branches:
   only:
+    - sandbox
+    - development
     - qa
     - production
 env:

--- a/.vercel/ignored-build-step.sh
+++ b/.vercel/ignored-build-step.sh
@@ -5,7 +5,7 @@ echo "VERCEL_GIT_COMMIT_REF: $VERCEL_GIT_COMMIT_REF"
 
 if [[ "$VERCEL_GIT_COMMIT_REF" == "sandbox" || "$VERCEL_GIT_COMMIT_REF" == "development" || "$VERCEL_GIT_COMMIT_REF" == "qa" || "$VERCEL_GIT_COMMIT_REF" == "production"  ]] ; then
   # Don't build a preview.
-  echo "🛑 - Skipping build for sandbox, development, qa, or production branch detected."
+  echo "🛑 - Skipping build: sandbox, development, qa, or production branch detected."
   exit 0;
 
 else

--- a/.vercel/ignored-build-step.sh
+++ b/.vercel/ignored-build-step.sh
@@ -3,9 +3,9 @@
 # @see https://vercel.com/docs/concepts/projects/environment-variables#system-environment-variables
 echo "VERCEL_GIT_COMMIT_REF: $VERCEL_GIT_COMMIT_REF"
 
-if [[ "$VERCEL_GIT_COMMIT_REF" == "qa" || "$VERCEL_GIT_COMMIT_REF" == "production"  ]] ; then
+if [[ "$VERCEL_GIT_COMMIT_REF" == "sandbox" || "$VERCEL_GIT_COMMIT_REF" == "development" || "$VERCEL_GIT_COMMIT_REF" == "qa" || "$VERCEL_GIT_COMMIT_REF" == "production"  ]] ; then
   # Don't build a preview.
-  echo "🛑 - Skipping build for qa or production branch"
+  echo "🛑 - Skipping build for sandbox, development, qa, or production branch detected."
   exit 0;
 
 else

--- a/provisioning/set-env
+++ b/provisioning/set-env
@@ -14,6 +14,19 @@ SENDGRID_EMAIL_ENABLE=true
 NEXT_PUBLIC_DRUPAL_PREVIEW_SECRET=o934Ysf3Hpu3irVXFBYvGCAyHjU3F
 DRUPAL_CONSUMER_UUID=0dbf647e-972b-4235-890b-0a23a3201b4e
 
+if [ "$TRAVIS_BRANCH" == "development" ]; then
+  NEXT_PUBLIC_SERVER_ENV=dev
+  NEXT_PUBLIC_NYPL_DOMAIN=https://dev-www.nypl.org
+  REFINERY_API=https://qa-refinery.nypl.org/api/nypl
+  DRUPAL_API=https://dev-drupal.nypl.org
+  GRAPHQL_API_URL=https://dev-scout.nypl.org/api/graphql
+  GA_TRACKING_ID=UA-1420324-122
+  ALLOWED_ORIGIN=https://dev-www.nypl.org
+  SENDGRID_EMAIL_ENABLE=true
+  NEXT_PUBLIC_DRUPAL_PREVIEW_SECRET=o934Ysf3Hpu3irVXFBYvGCAyHjU3F
+  DRUPAL_CONSUMER_UUID=0dbf647e-972b-4235-890b-0a23a3201b4e
+fi
+
 if [ "$TRAVIS_BRANCH" == "qa" ]; then
   NEXT_PUBLIC_SERVER_ENV=qa
   NEXT_PUBLIC_NYPL_DOMAIN=https://qa-www.nypl.org

--- a/provisioning/set-env
+++ b/provisioning/set-env
@@ -14,6 +14,20 @@ SENDGRID_EMAIL_ENABLE=true
 NEXT_PUBLIC_DRUPAL_PREVIEW_SECRET=o934Ysf3Hpu3irVXFBYvGCAyHjU3F
 DRUPAL_CONSUMER_UUID=0dbf647e-972b-4235-890b-0a23a3201b4e
 
+# Some of these env vars depend on QA instances for now, since on Pantheon there is technically no dedicated "sandbox" instance.
+if [ "$TRAVIS_BRANCH" == "sandbox" ]; then
+  NEXT_PUBLIC_SERVER_ENV=sandbox
+  NEXT_PUBLIC_NYPL_DOMAIN=https://sandbox-scout.nypl.org
+  REFINERY_API=https://qa-refinery.nypl.org/api/nypl
+  DRUPAL_API=https://qa-drupal.nypl.org
+  GRAPHQL_API_URL=https://sandbox-scout.nypl.org/api/graphql
+  GA_TRACKING_ID=UA-1420324-122
+  ALLOWED_ORIGIN=https://sandbox-scout.nypl.org
+  SENDGRID_EMAIL_ENABLE=true
+  NEXT_PUBLIC_DRUPAL_PREVIEW_SECRET=o934Ysf3Hpu3irVXFBYvGCAyHjU3F
+  DRUPAL_CONSUMER_UUID=0dbf647e-972b-4235-890b-0a23a3201b4e
+fi
+
 if [ "$TRAVIS_BRANCH" == "development" ]; then
   NEXT_PUBLIC_SERVER_ENV=dev
   NEXT_PUBLIC_NYPL_DOMAIN=https://dev-www.nypl.org


### PR DESCRIPTION
**This PR does the following:**
- Update `.travis.yml` to build on `development` and `sandbox` branches.
- Update `set-env` bash script to set Scout environment variables for `development` and `sandbox`
- Update vercel ignored build step script to skip builds for `development` or `sandbox`

