### PR TITLE
SEB-2535 Build File Syncing for Volumes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,10 @@ COPY . .
 
 RUN npm run build
 
+# Copy .next to temp location for deployment
+RUN cp -Rpf /app/.next /tmp/.next
+
 # Explicitly set port 3000 as open to requests.
 EXPOSE 3000
 
-CMD [ "npm", "start" ]
+CMD [ "sh", "provisioning/ecs-start" ]

--- a/provisioning/app-start
+++ b/provisioning/app-start
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Copy pre-built .next to the shared cache location during deployment.
+cp -Rpf /tmp/.next /app/.next
+# Remove temporary files, if necessary
+# rm -rf /tmp/.next
+# Start the app
+npm start

--- a/provisioning/set-env
+++ b/provisioning/set-env
@@ -19,7 +19,7 @@ if [ "$TRAVIS_BRANCH" == "sandbox" ]; then
   NEXT_PUBLIC_SERVER_ENV=sandbox
   NEXT_PUBLIC_NYPL_DOMAIN=https://sandbox-scout.nypl.org
   REFINERY_API=https://qa-refinery.nypl.org/api/nypl
-  DRUPAL_API=https://qa-drupal.nypl.org
+  DRUPAL_API=https://pr1022-nypl1.pantheonsite.io
   GRAPHQL_API_URL=https://sandbox-scout.nypl.org/api/graphql
   GA_TRACKING_ID=UA-1420324-122
   ALLOWED_ORIGIN=https://sandbox-scout.nypl.org

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -78,8 +78,8 @@ export const getStaticProps = withDrupalRouter(async function (
       }),
       initialApolloState: apolloClient.cache.extract(),
     },
-    // Set revalidate to 1 min.
-    revalidate: 60,
+    // Turn off request based revalidation.
+    revalidate: false,
   };
 });
 


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/SEB-2535)

**This PR does the following:**
- Adds instructions to Docker to copy .next files to a tmp location after build to sync with a shared cache volume.
- Includes a provisioning script to run as the new CMD for copying .next files and starting the app

### Review Steps:
- [ ] Run docker build then run. Application should run normally on local machines
- [ ] Upon deployment, ECS tasks should run the command to copy .next directory files prior to startup
- [ ] Hosted application runs without error
