### PR TITLE
RENO-3367: Add Source Code Field To EmailSubscription Query

### DIFF
--- a/src/apollo/server/resolvers/utils/resolveDrupalParagraphs.ts
+++ b/src/apollo/server/resolvers/utils/resolveDrupalParagraphs.ts
@@ -424,7 +424,7 @@ export default function resolveDrupalParagraphs(
           description: item.field_tfls_description?.processed,
           formPlaceholder: item.field_ts_placeholder,
           salesforceListId: item.field_ts_salesforce_list_id,
-          sourceCode: item.field_ts_salesforce_source_code,
+          salesforceSourceCode: item.field_ts_salesforce_source_code,
           colorway: slug ? getColorway(slug) : null,
         };
         break;

--- a/src/apollo/server/resolvers/utils/resolveDrupalParagraphs.ts
+++ b/src/apollo/server/resolvers/utils/resolveDrupalParagraphs.ts
@@ -424,6 +424,7 @@ export default function resolveDrupalParagraphs(
           description: item.field_tfls_description?.processed,
           formPlaceholder: item.field_ts_placeholder,
           salesforceListId: item.field_ts_salesforce_list_id,
+          sourceCode: item.field_ts_salesforce_source_code,
           colorway: slug ? getColorway(slug) : null,
         };
         break;

--- a/src/apollo/server/type-defs/shared.js
+++ b/src/apollo/server/type-defs/shared.js
@@ -229,7 +229,7 @@ export const typeDefs = gql`
     description: String
     formPlaceholder: String
     salesforceListId: String
-    sourceCode: String
+    salesforceSourceCode: String
     colorway: Colorway
   }
 `;

--- a/src/apollo/server/type-defs/shared.js
+++ b/src/apollo/server/type-defs/shared.js
@@ -229,6 +229,7 @@ export const typeDefs = gql`
     description: String
     formPlaceholder: String
     salesforceListId: String
+    sourceCode: String
     colorway: Colorway
   }
 `;

--- a/src/components/section-fronts/SectionFrontPage/SectionFrontPage.tsx
+++ b/src/components/section-fronts/SectionFrontPage/SectionFrontPage.tsx
@@ -124,7 +124,7 @@ export const SECTION_FRONT_QUERY = gql`
           description
           formPlaceholder
           salesforceListId
-          sourceCode
+          salesforceSourceCode
           colorway {
             primary
           }

--- a/src/components/section-fronts/SectionFrontPage/SectionFrontPage.tsx
+++ b/src/components/section-fronts/SectionFrontPage/SectionFrontPage.tsx
@@ -124,6 +124,7 @@ export const SECTION_FRONT_QUERY = gql`
           description
           formPlaceholder
           salesforceListId
+          sourceCode
           colorway {
             primary
           }

--- a/src/components/shared/EmailSubscription/EmailSubscription.tsx
+++ b/src/components/shared/EmailSubscription/EmailSubscription.tsx
@@ -27,7 +27,7 @@ export default function EmailSubscription({
   // @TODO confirm with UX what the default color should be
   bgColor = "section.research.primary",
   // @TODO should this even be a prop? I imagine this will be the same for all newsletters?
-  formBaseUrl = "/api/salesforce?email",
+  formBaseUrl = "/api/salesforce",
   // @TODO formHelperText might be hardcoded for all Subscriptions
   formHelperText = "*To learn more about how the Library uses information you provide, please read our privacy and policy",
   formPlaceholder,
@@ -46,13 +46,18 @@ export default function EmailSubscription({
     setIsSubmitting(true);
     if (formBaseUrl !== undefined) {
       // API endpoint where we send form data.
-      const endpoint = `${formBaseUrl}=${e.target.email.value}&list_id=${salesforceListId}&source_code=${sourceCode}`;
+      const endpoint = `${formBaseUrl}`;
       // Form the request for sending data to the server.
       const options = {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
+        body: JSON.stringify({
+          email: e.target.email.value,
+          list_id: salesforceListId,
+          source_code: sourceCode,
+        }),
       };
 
       // Send the form and await response.

--- a/src/components/shared/EmailSubscription/EmailSubscription.tsx
+++ b/src/components/shared/EmailSubscription/EmailSubscription.tsx
@@ -16,7 +16,7 @@ interface EmailSubscriptionProps {
   formHelperText?: string;
   formPlaceholder?: string;
   salesforceListId?: number;
-  sourceCode?: string;
+  salesforceSourceCode?: string;
 }
 
 export default function EmailSubscription({
@@ -31,8 +31,7 @@ export default function EmailSubscription({
   // @TODO formHelperText might be hardcoded for all Subscriptions
   formHelperText = "*To learn more about how the Library uses information you provide, please read our <a target='_blank' rel='noopener noreferrer' href='https://www.nypl.org/help/about-nypl/legal-notices/privacy-policy'>privacy and policy</a>",
   formPlaceholder,
-  // @TODO should there be a fall back value?
-  sourceCode,
+  salesforceSourceCode,
   salesforceListId,
 }: EmailSubscriptionProps): JSX.Element {
   const [input, setInput] = React.useState("");
@@ -56,7 +55,7 @@ export default function EmailSubscription({
         body: JSON.stringify({
           email: e.target.email.value,
           list_id: salesforceListId,
-          source_code: sourceCode,
+          source_code: salesforceSourceCode,
         }),
       };
 

--- a/src/components/shared/EmailSubscription/EmailSubscription.tsx
+++ b/src/components/shared/EmailSubscription/EmailSubscription.tsx
@@ -16,6 +16,7 @@ interface EmailSubscriptionProps {
   formHelperText?: string;
   formPlaceholder?: string;
   salesforceListId?: number;
+  sourceCode?: string;
 }
 
 export default function EmailSubscription({
@@ -30,6 +31,8 @@ export default function EmailSubscription({
   // @TODO formHelperText might be hardcoded for all Subscriptions
   formHelperText = "*To learn more about how the Library uses information you provide, please read our privacy and policy",
   formPlaceholder,
+  // @TODO should there be a fall back value?
+  sourceCode,
   salesforceListId,
 }: EmailSubscriptionProps): JSX.Element {
   const [input, setInput] = React.useState("");
@@ -37,8 +40,6 @@ export default function EmailSubscription({
   const [isSubmitting, setIsSubmitting] = React.useState(false);
 
   const [status, setStatus] = React.useState<StatusCode>();
-  // @TDOD Replace this hard coded string with a dynamic value TBD
-  const sourceCode = "Scout Test Source Code";
 
   const handleSubmit = async (e: any) => {
     e.preventDefault();

--- a/src/components/shared/EmailSubscription/EmailSubscription.tsx
+++ b/src/components/shared/EmailSubscription/EmailSubscription.tsx
@@ -29,7 +29,7 @@ export default function EmailSubscription({
   // @TODO should this even be a prop? I imagine this will be the same for all newsletters?
   formBaseUrl = "/api/salesforce",
   // @TODO formHelperText might be hardcoded for all Subscriptions
-  formHelperText = "*To learn more about how the Library uses information you provide, please read our privacy and policy",
+  formHelperText = "*To learn more about how the Library uses information you provide, please read our <a target='_blank' rel='noopener noreferrer' href='https://www.nypl.org/help/about-nypl/legal-notices/privacy-policy'>privacy and policy</a>",
   formPlaceholder,
   // @TODO should there be a fall back value?
   sourceCode,

--- a/src/components/shared/EmailSubscription/EmailSubscriptionForm.tsx
+++ b/src/components/shared/EmailSubscription/EmailSubscriptionForm.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import {
   Button,
+  Box,
   Form,
   FormField,
   FormRow,
@@ -16,7 +17,7 @@ interface EmailSubscriptionFormProps {
   onChange: (e: string) => void;
   formInput?: string;
   formPlaceholder?: string;
-  formHelperText?: string;
+  formHelperText: string;
 }
 
 export default function EmailSubscriptionForm({
@@ -68,9 +69,14 @@ export default function EmailSubscriptionForm({
           </FormField>
         </FormRow>
       </Form>
-      <Text isItalic mt="1rem" fontSize="-1">
-        {formHelperText}
-      </Text>
+      <Box
+        as="p"
+        fontStyle="italic"
+        mt="1rem"
+        fontSize="-1"
+        sx={{ a: { color: "ui.white", textDecoration: "underline" } }}
+        dangerouslySetInnerHTML={{ __html: formHelperText }}
+      />
     </>
   );
 }

--- a/src/pages/api/salesforce.ts
+++ b/src/pages/api/salesforce.ts
@@ -13,11 +13,11 @@ export default async function handler(
     SALESFORCE_ENABLE,
   } = process.env;
 
-  if (!request.query.email) {
+  if (!request.body.email) {
     return response.status(401).json({ message: "No email provided." });
   }
 
-  if (!request.query.list_id) {
+  if (!request.body.list_id) {
     return response.status(401).json({ message: "No list id provided." });
   }
 
@@ -33,17 +33,17 @@ export default async function handler(
       try {
         // Try to add a new Subscriber
         const soapCreate = await sfmc.soap.create("Subscriber", {
-          SubscriberKey: request.query.email,
-          EmailAddress: request.query.email,
+          SubscriberKey: request.body.email,
+          EmailAddress: request.body.email,
           Attributes: [
             {
               Name: "Source Code",
-              Value: request.query.source_code,
+              Value: request.body.source_code,
             },
           ],
           Lists: [
             {
-              ID: request.query.list_id,
+              ID: request.body.list_id,
               Status: "Active",
             },
           ],
@@ -53,27 +53,27 @@ export default async function handler(
           statusCode: "SUCCESS",
           statusMessage: soapCreate.Results[0].StatusMessage,
           formData: {
-            email: request.query.email,
+            email: request.body.email,
           },
         });
       } catch (e: any) {
         // If the Subscriber already exists, update the Subscriber
         if (e.json.Results[0].ErrorCode === 12014) {
           const soapUpdate = await sfmc.soap.update("Subscriber", {
-            SubscriberKey: request.query.email,
-            EmailAddress: request.query.email,
+            SubscriberKey: request.body.email,
+            EmailAddress: request.body.email,
             // Make sure that if a subscriber was previously "Unsubscribed" the account gets activated
             Status: "Active",
             Attributes: [
               {
                 Name: "Source Code",
-                // @TODO this should be a dynamic value, and be passed as a query param?
-                Value: request.query.source_code,
+                // @TODO this should be a dynamic value, and be passed as a body param?
+                Value: request.body.source_code,
               },
             ],
             Lists: [
               {
-                ID: request.query.list_id,
+                ID: request.body.list_id,
                 Status: "Active",
               },
             ],
@@ -83,7 +83,7 @@ export default async function handler(
             statusCode: "SUCCESS",
             statusMessage: soapUpdate.Results[0].StatusMessage,
             formData: {
-              email: request.query.email,
+              email: request.body.email,
             },
           });
         }
@@ -104,7 +104,7 @@ export default async function handler(
       statusCode: "TEST_MODE",
       statusMessage: "Api is in test mode. No data was sent to salesforce.",
       formData: {
-        email: request.query.email,
+        email: request.body.email,
       },
     });
   }

--- a/src/pages/api/salesforce.ts
+++ b/src/pages/api/salesforce.ts
@@ -21,6 +21,10 @@ export default async function handler(
     return response.status(401).json({ message: "No list id provided." });
   }
 
+  if (!request.body.source_code) {
+    return response.status(401).json({ message: "No source code provided." });
+  }
+
   if (SALESFORCE_ENABLE === "true") {
     const sfmc = new SDK({
       client_id: SALESFORCE_CLIENT_ID,


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-3367)

**This PR does the following:**
- Adds the Drupal sourceCode field to the EmailSubscription graphQL query
- Appends the data to the request body for the salesforce api call
- Updates the formHelperText with the link to privacy and policy

### Review Steps:
- [ ] Pull in branch `git fetch origin RENO-3367/add-sourceCode-field-from-drupal`
- [ ] Switch to relevant brach `git checkout RENO-3367/add-sourceCode-field-from-drupal`
- [ ] Start a local build `npm run build && npm start`
- [ ] Confirm tests are passing `npm test`
- [ ] Visit [Local Research page](http://localhost:3000/research)
- [ ] Fill out and submit the Email Subscription form
- [ ] Confirm that the subscription confirmation appears on the page
- [ ] Log into Salesforce and confirm that the email was added to the Test_Signups list
- [ ] Confirm that the saved Source Code value is 'research'


### Front End Review Steps:
- [ ] View [Local Research page](http://localhost:3000/research)
- [ ] Confirm that the privacy and policy text is a link
- [ ] Confirm that the link directs to the [correct page](https://www.nypl.org/help/about-nypl/legal-notices/privacy-policy)
