### PR TITLE
Reno 3384: Update Success and Privacy Disclaimer Message

### DIFF
--- a/src/components/shared/EmailSubscription/EmailSubscription.tsx
+++ b/src/components/shared/EmailSubscription/EmailSubscription.tsx
@@ -27,8 +27,7 @@ export default function EmailSubscription({
   bgColor = "section.research.primary",
   // @TODO should this even be a prop? I imagine this will be the same for all newsletters?
   formBaseUrl = "/api/salesforce?email",
-  // @TODO formHelperText might be hardcoded for all Subscriptions
-  formHelperText = "*To learn more about how the Library uses information you provide, please read our privacy and policy",
+  formHelperText = "*You will receive email updates from the Library, and you will be able to unsubscribe at any time. To learn more about how the Library uses information you provide, please read our <a target='_blank' rel='noopener noreferrer' href='https://www.nypl.org/help/about-nypl/legal-notices/privacy-policy'>privacy policy</a>.",
   formPlaceholder,
   salesforceListId,
 }: EmailSubscriptionProps): JSX.Element {

--- a/src/components/shared/EmailSubscription/EmailSubscriptionConfirmation.tsx
+++ b/src/components/shared/EmailSubscription/EmailSubscriptionConfirmation.tsx
@@ -29,7 +29,7 @@ export default function EmailSubscriptionConfirmation({
 }: EmailSubscriptionConfirmationProps) {
   function getStatusMessage(status: StatusCode) {
     if (status === "SUCCESS") {
-      return "Success message to go here Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt consectetur adipiscing elit";
+      return "Thank you! You have successfully subscribed to our email updates! You can update your email subscription preferences at any time using the links at the bottom of the email.";
     }
     if (status === "ERROR") {
       return "Error message to go here Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt consectetur adipiscing elit";

--- a/src/components/shared/EmailSubscription/EmailSubscriptionForm.tsx
+++ b/src/components/shared/EmailSubscription/EmailSubscriptionForm.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import {
   Button,
+  Box,
   Form,
   FormField,
   FormRow,
@@ -16,7 +17,7 @@ interface EmailSubscriptionFormProps {
   onChange: (e: string) => void;
   formInput?: string;
   formPlaceholder?: string;
-  formHelperText?: string;
+  formHelperText: string;
 }
 
 export default function EmailSubscriptionForm({
@@ -68,9 +69,13 @@ export default function EmailSubscriptionForm({
           </FormField>
         </FormRow>
       </Form>
-      <Text isItalic mt="1rem" fontSize="-1">
-        {formHelperText}
-      </Text>
+      <Box
+        textDecoration="italic"
+        mt="1rem"
+        fontSize="-1"
+        dangerouslySetInnerHTML={{ __html: formHelperText }}
+        sx={{ a: { color: "ui.white", textDecoration: "underline" } }}
+      />
     </>
   );
 }

--- a/src/components/shared/EmailSubscription/EmailSubscriptionForm.tsx
+++ b/src/components/shared/EmailSubscription/EmailSubscriptionForm.tsx
@@ -46,6 +46,7 @@ export default function EmailSubscriptionForm({
         <FormRow gridTemplateColumns={{ base: "repeat(1fr)", md: "2fr auto" }}>
           <FormField>
             <TextInput
+              isRequired
               id={`email-input-${id}`}
               labelText="Email subscription"
               value={formInput}

--- a/src/components/shared/EmailSubscription/EmailSubscriptionWrapper.tsx
+++ b/src/components/shared/EmailSubscription/EmailSubscriptionWrapper.tsx
@@ -24,7 +24,7 @@ export default function EmailSubscriptionWrapper({
       justifyContent="center"
       alignItems="center"
       width="full"
-      minH="300px"
+      minH="350px"
       padding="l"
       bgColor={bgColor}
       color={headingColor}


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-3384)

**This PR does the following:**
- Updates Success confirmation message with the text provided by comms
- Updates the privacy policy disclaimer with the text provided by comms
- Updates the privacy text to include the link to NYPL privacy policy - if clicked the link will open in a new tab
- Updates the min height of the EmailSubscription Wrapper to match [Figma designs](https://www.figma.com/file/HhtAEYL9QFZ6PPXTu75T0H/Newsletter-Component?node-id=1619%3A28678&t=jDBlzBLnhW7SI0dI-0)
- Adds isRequired prop to the EmailSubscription TextInput 

### Review Steps:
- [ ] Pull in branch `git fetch origin RENO-3384/update-success-and-privacy-text`
- [ ] Switch to relevant brach `git checkout RENO-3384/update-success-and-privacy-text`
- [ ] Start a local build `npm run build && npm start`
- [ ] Confirm tests are passing `npm test`

### Front End Review Steps:
- [ ] View [Local Research Section Front page](http://localhost:3000/research)
- [ ] Confirm the privacy disclaimer in the Email Subscription component matches the provided text on the Jira Ticket
- [ ] Confirm that after submitting an email address the Success message matches the provided text on the Jira Ticket

