### PR TITLE
RENO-3378: Fix seeMore Button

### DIFF
--- a/src/components/home-v1/CardGrid/CardGrid.test.tsx
+++ b/src/components/home-v1/CardGrid/CardGrid.test.tsx
@@ -92,6 +92,7 @@ const items = [
     url: "https://www.nypl.org/",
   },
 ];
+const seeMore = { text: "see More", link: "https://www.nypl.org/" };
 
 describe("Card tests", () => {
   it("should pass axe accessibility tests", async () => {
@@ -131,6 +132,7 @@ describe("CardGrid tests", () => {
         title="Test title"
         link="https://nypl.com"
         items={items}
+        seeMore={seeMore}
       />
     );
     expect(await axe(container)).toHaveNoViolations();
@@ -142,12 +144,24 @@ describe("CardGrid tests", () => {
         title="Test title"
         link="https://nypl.com"
         items={items}
+        seeMore={seeMore}
       />
     );
     expect(screen.getAllByRole("listitem")).toHaveLength(4);
   });
   it("should render the UI snapshot correctly", () => {
-    const cardGrid = renderer
+    const cardGridWithSeeMore = renderer
+      .create(
+        <CardGrid
+          id={"card-grid-test-id"}
+          title="Test title"
+          link="https://nypl.com"
+          items={items}
+          seeMore={seeMore}
+        />
+      )
+      .toJSON();
+    const cardGridWithoutSeeMore = renderer
       .create(
         <CardGrid
           id={"card-grid-test-id"}
@@ -157,6 +171,7 @@ describe("CardGrid tests", () => {
         />
       )
       .toJSON();
-    expect(cardGrid).toMatchSnapshot();
+    expect(cardGridWithSeeMore).toMatchSnapshot();
+    expect(cardGridWithoutSeeMore).toMatchSnapshot();
   });
 });

--- a/src/components/home-v1/CardGrid/__snapshots__/CardGrid.test.tsx.snap
+++ b/src/components/home-v1/CardGrid/__snapshots__/CardGrid.test.tsx.snap
@@ -760,8 +760,637 @@ exports[`CardGrid tests should render the UI snapshot correctly 1`] = `
     >
       <div
         className="css-i2lecr"
-      />
+      >
+        <a
+          aria-label="see more of Test title"
+          className="css-13vuhn9"
+          href="https://www.nypl.org/"
+          id="component-wrapper-seeMore-link-card-grid-test-id"
+          onClick={[Function]}
+        >
+          see More
+        </a>
+      </div>
     </div>
+  </div>
+</div>
+`;
+
+exports[`CardGrid tests should render the UI snapshot correctly 2`] = `
+<div
+  className="css-15j2i3p"
+>
+  <div
+    className="css-1ngwrio"
+  >
+    <div
+      className="css-hze00u"
+    >
+      <div
+        className="css-1ncw6ex"
+      >
+        <h2
+          className="chakra-heading css-18pkilg"
+          id="component-wrapper-heading-card-grid-test-id"
+        >
+          <a
+            className="css-0"
+            href="https://nypl.com"
+            id="component-wrapper-heading-link-card-grid-test-id"
+            onClick={[Function]}
+          >
+            Test title
+          </a>
+        </h2>
+      </div>
+    </div>
+    <div
+      className="css-1y2jlch"
+    >
+      <ul
+        className="css-lgj0h8"
+      >
+        <li
+          className="css-155za0w"
+          id="card-grid-item-test-id-1"
+        >
+          <div
+            className="css-pgu20y"
+            id="card-test-id-1"
+          >
+            <div
+              className="textBox css-0"
+            >
+              <h3
+                className="chakra-heading css-0"
+              >
+                <a
+                  className="css-0"
+                  href="https://www.nypl.org/"
+                  onClick={[Function]}
+                >
+                  Test
+                </a>
+              </h3>
+              <div
+                className="details css-0"
+              />
+            </div>
+            <div
+              className="css-ys3583"
+              id="card-image-test-id-1"
+            >
+              <a
+                aria-label="Test-image"
+                className="css-0"
+                href="https://www.nypl.org/"
+                id="card-image-link-test-id-1"
+                onClick={[Function]}
+                tabIndex={-1}
+              >
+                <div
+                  className="scout-nextjs-image"
+                  id="nextjsImage-card-image-test-id-1"
+                >
+                  <span
+                    style={
+                      Object {
+                        "background": "none",
+                        "border": 0,
+                        "boxSizing": "border-box",
+                        "display": "block",
+                        "height": "initial",
+                        "margin": 0,
+                        "opacity": 1,
+                        "overflow": "hidden",
+                        "padding": 0,
+                        "position": "relative",
+                        "width": "initial",
+                      }
+                    }
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "none",
+                          "border": 0,
+                          "boxSizing": "border-box",
+                          "display": "block",
+                          "height": "initial",
+                          "margin": 0,
+                          "opacity": 1,
+                          "padding": 0,
+                          "paddingTop": "50%",
+                          "width": "initial",
+                        }
+                      }
+                    />
+                    <img
+                      alt="image-1-alt-text"
+                      data-nimg="responsive"
+                      decoding="async"
+                      onError={[Function]}
+                      onLoad={[Function]}
+                      src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+                      style={
+                        Object {
+                          "border": "none",
+                          "bottom": 0,
+                          "boxSizing": "border-box",
+                          "display": "block",
+                          "height": 0,
+                          "left": 0,
+                          "margin": "auto",
+                          "maxHeight": "100%",
+                          "maxWidth": "100%",
+                          "minHeight": "100%",
+                          "minWidth": "100%",
+                          "objectFit": undefined,
+                          "objectPosition": undefined,
+                          "padding": 0,
+                          "position": "absolute",
+                          "right": 0,
+                          "top": 0,
+                          "width": 0,
+                        }
+                      }
+                    />
+                    <noscript>
+                      <img
+                        alt="image-1-alt-text"
+                        data-nimg="responsive"
+                        decoding="async"
+                        loading="lazy"
+                        sizes="100vw"
+                        src="/_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=3840&q=90"
+                        srcSet="/_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=640&q=90 640w, /_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=750&q=90 750w, /_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=828&q=90 828w, /_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=1080&q=90 1080w, /_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=1200&q=90 1200w, /_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=1920&q=90 1920w, /_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=2048&q=90 2048w, /_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=3840&q=90 3840w"
+                        style={
+                          Object {
+                            "border": "none",
+                            "bottom": 0,
+                            "boxSizing": "border-box",
+                            "display": "block",
+                            "height": 0,
+                            "left": 0,
+                            "margin": "auto",
+                            "maxHeight": "100%",
+                            "maxWidth": "100%",
+                            "minHeight": "100%",
+                            "minWidth": "100%",
+                            "objectFit": undefined,
+                            "objectPosition": undefined,
+                            "padding": 0,
+                            "position": "absolute",
+                            "right": 0,
+                            "top": 0,
+                            "width": 0,
+                          }
+                        }
+                      />
+                    </noscript>
+                  </span>
+                </div>
+              </a>
+            </div>
+          </div>
+        </li>
+        <li
+          className="css-155za0w"
+          id="card-grid-item-test-id-2"
+        >
+          <div
+            className="css-pgu20y"
+            id="card-test-id-2"
+          >
+            <div
+              className="textBox css-0"
+            >
+              <h3
+                className="chakra-heading css-0"
+              >
+                <a
+                  className="css-0"
+                  href="https://www.nypl.org/"
+                  onClick={[Function]}
+                >
+                  Test
+                </a>
+              </h3>
+              <div
+                className="details css-0"
+              />
+            </div>
+            <div
+              className="css-ys3583"
+              id="card-image-test-id-2"
+            >
+              <a
+                aria-label="Test-image"
+                className="css-0"
+                href="https://www.nypl.org/"
+                id="card-image-link-test-id-2"
+                onClick={[Function]}
+                tabIndex={-1}
+              >
+                <div
+                  className="scout-nextjs-image"
+                  id="nextjsImage-card-image-test-id-2"
+                >
+                  <span
+                    style={
+                      Object {
+                        "background": "none",
+                        "border": 0,
+                        "boxSizing": "border-box",
+                        "display": "block",
+                        "height": "initial",
+                        "margin": 0,
+                        "opacity": 1,
+                        "overflow": "hidden",
+                        "padding": 0,
+                        "position": "relative",
+                        "width": "initial",
+                      }
+                    }
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "none",
+                          "border": 0,
+                          "boxSizing": "border-box",
+                          "display": "block",
+                          "height": "initial",
+                          "margin": 0,
+                          "opacity": 1,
+                          "padding": 0,
+                          "paddingTop": "50%",
+                          "width": "initial",
+                        }
+                      }
+                    />
+                    <img
+                      alt="image-2-alt-text"
+                      data-nimg="responsive"
+                      decoding="async"
+                      onError={[Function]}
+                      onLoad={[Function]}
+                      src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+                      style={
+                        Object {
+                          "border": "none",
+                          "bottom": 0,
+                          "boxSizing": "border-box",
+                          "display": "block",
+                          "height": 0,
+                          "left": 0,
+                          "margin": "auto",
+                          "maxHeight": "100%",
+                          "maxWidth": "100%",
+                          "minHeight": "100%",
+                          "minWidth": "100%",
+                          "objectFit": undefined,
+                          "objectPosition": undefined,
+                          "padding": 0,
+                          "position": "absolute",
+                          "right": 0,
+                          "top": 0,
+                          "width": 0,
+                        }
+                      }
+                    />
+                    <noscript>
+                      <img
+                        alt="image-2-alt-text"
+                        data-nimg="responsive"
+                        decoding="async"
+                        loading="lazy"
+                        sizes="100vw"
+                        src="/_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=3840&q=90"
+                        srcSet="/_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=640&q=90 640w, /_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=750&q=90 750w, /_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=828&q=90 828w, /_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=1080&q=90 1080w, /_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=1200&q=90 1200w, /_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=1920&q=90 1920w, /_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=2048&q=90 2048w, /_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=3840&q=90 3840w"
+                        style={
+                          Object {
+                            "border": "none",
+                            "bottom": 0,
+                            "boxSizing": "border-box",
+                            "display": "block",
+                            "height": 0,
+                            "left": 0,
+                            "margin": "auto",
+                            "maxHeight": "100%",
+                            "maxWidth": "100%",
+                            "minHeight": "100%",
+                            "minWidth": "100%",
+                            "objectFit": undefined,
+                            "objectPosition": undefined,
+                            "padding": 0,
+                            "position": "absolute",
+                            "right": 0,
+                            "top": 0,
+                            "width": 0,
+                          }
+                        }
+                      />
+                    </noscript>
+                  </span>
+                </div>
+              </a>
+            </div>
+          </div>
+        </li>
+        <li
+          className="css-155za0w"
+          id="card-grid-item-test-id-3"
+        >
+          <div
+            className="css-pgu20y"
+            id="card-test-id-3"
+          >
+            <div
+              className="textBox css-0"
+            >
+              <h3
+                className="chakra-heading css-0"
+              >
+                <a
+                  className="css-0"
+                  href="https://www.nypl.org/"
+                  onClick={[Function]}
+                >
+                  Test
+                </a>
+              </h3>
+              <div
+                className="details css-0"
+              />
+            </div>
+            <div
+              className="css-ys3583"
+              id="card-image-test-id-3"
+            >
+              <a
+                aria-label="Test-image"
+                className="css-0"
+                href="https://www.nypl.org/"
+                id="card-image-link-test-id-3"
+                onClick={[Function]}
+                tabIndex={-1}
+              >
+                <div
+                  className="scout-nextjs-image"
+                  id="nextjsImage-card-image-test-id-3"
+                >
+                  <span
+                    style={
+                      Object {
+                        "background": "none",
+                        "border": 0,
+                        "boxSizing": "border-box",
+                        "display": "block",
+                        "height": "initial",
+                        "margin": 0,
+                        "opacity": 1,
+                        "overflow": "hidden",
+                        "padding": 0,
+                        "position": "relative",
+                        "width": "initial",
+                      }
+                    }
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "none",
+                          "border": 0,
+                          "boxSizing": "border-box",
+                          "display": "block",
+                          "height": "initial",
+                          "margin": 0,
+                          "opacity": 1,
+                          "padding": 0,
+                          "paddingTop": "50%",
+                          "width": "initial",
+                        }
+                      }
+                    />
+                    <img
+                      alt="image-3-alt-text"
+                      data-nimg="responsive"
+                      decoding="async"
+                      onError={[Function]}
+                      onLoad={[Function]}
+                      src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+                      style={
+                        Object {
+                          "border": "none",
+                          "bottom": 0,
+                          "boxSizing": "border-box",
+                          "display": "block",
+                          "height": 0,
+                          "left": 0,
+                          "margin": "auto",
+                          "maxHeight": "100%",
+                          "maxWidth": "100%",
+                          "minHeight": "100%",
+                          "minWidth": "100%",
+                          "objectFit": undefined,
+                          "objectPosition": undefined,
+                          "padding": 0,
+                          "position": "absolute",
+                          "right": 0,
+                          "top": 0,
+                          "width": 0,
+                        }
+                      }
+                    />
+                    <noscript>
+                      <img
+                        alt="image-3-alt-text"
+                        data-nimg="responsive"
+                        decoding="async"
+                        loading="lazy"
+                        sizes="100vw"
+                        src="/_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=3840&q=90"
+                        srcSet="/_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=640&q=90 640w, /_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=750&q=90 750w, /_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=828&q=90 828w, /_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=1080&q=90 1080w, /_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=1200&q=90 1200w, /_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=1920&q=90 1920w, /_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=2048&q=90 2048w, /_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=3840&q=90 3840w"
+                        style={
+                          Object {
+                            "border": "none",
+                            "bottom": 0,
+                            "boxSizing": "border-box",
+                            "display": "block",
+                            "height": 0,
+                            "left": 0,
+                            "margin": "auto",
+                            "maxHeight": "100%",
+                            "maxWidth": "100%",
+                            "minHeight": "100%",
+                            "minWidth": "100%",
+                            "objectFit": undefined,
+                            "objectPosition": undefined,
+                            "padding": 0,
+                            "position": "absolute",
+                            "right": 0,
+                            "top": 0,
+                            "width": 0,
+                          }
+                        }
+                      />
+                    </noscript>
+                  </span>
+                </div>
+              </a>
+            </div>
+          </div>
+        </li>
+        <li
+          className="css-155za0w"
+          id="card-grid-item-test-id-4"
+        >
+          <div
+            className="css-pgu20y"
+            id="card-test-id-4"
+          >
+            <div
+              className="textBox css-0"
+            >
+              <h3
+                className="chakra-heading css-0"
+              >
+                <a
+                  className="css-0"
+                  href="https://www.nypl.org/"
+                  onClick={[Function]}
+                >
+                  Test
+                </a>
+              </h3>
+              <div
+                className="details css-0"
+              />
+            </div>
+            <div
+              className="css-ys3583"
+              id="card-image-test-id-4"
+            >
+              <a
+                aria-label="Test-image"
+                className="css-0"
+                href="https://www.nypl.org/"
+                id="card-image-link-test-id-4"
+                onClick={[Function]}
+                tabIndex={-1}
+              >
+                <div
+                  className="scout-nextjs-image"
+                  id="nextjsImage-card-image-test-id-4"
+                >
+                  <span
+                    style={
+                      Object {
+                        "background": "none",
+                        "border": 0,
+                        "boxSizing": "border-box",
+                        "display": "block",
+                        "height": "initial",
+                        "margin": 0,
+                        "opacity": 1,
+                        "overflow": "hidden",
+                        "padding": 0,
+                        "position": "relative",
+                        "width": "initial",
+                      }
+                    }
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "none",
+                          "border": 0,
+                          "boxSizing": "border-box",
+                          "display": "block",
+                          "height": "initial",
+                          "margin": 0,
+                          "opacity": 1,
+                          "padding": 0,
+                          "paddingTop": "50%",
+                          "width": "initial",
+                        }
+                      }
+                    />
+                    <img
+                      alt="image-4-alt-text"
+                      data-nimg="responsive"
+                      decoding="async"
+                      onError={[Function]}
+                      onLoad={[Function]}
+                      src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+                      style={
+                        Object {
+                          "border": "none",
+                          "bottom": 0,
+                          "boxSizing": "border-box",
+                          "display": "block",
+                          "height": 0,
+                          "left": 0,
+                          "margin": "auto",
+                          "maxHeight": "100%",
+                          "maxWidth": "100%",
+                          "minHeight": "100%",
+                          "minWidth": "100%",
+                          "objectFit": undefined,
+                          "objectPosition": undefined,
+                          "padding": 0,
+                          "position": "absolute",
+                          "right": 0,
+                          "top": 0,
+                          "width": 0,
+                        }
+                      }
+                    />
+                    <noscript>
+                      <img
+                        alt="image-4-alt-text"
+                        data-nimg="responsive"
+                        decoding="async"
+                        loading="lazy"
+                        sizes="100vw"
+                        src="/_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=3840&q=90"
+                        srcSet="/_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=640&q=90 640w, /_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=750&q=90 750w, /_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=828&q=90 828w, /_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=1080&q=90 1080w, /_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=1200&q=90 1200w, /_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=1920&q=90 1920w, /_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=2048&q=90 2048w, /_next/image?url=https%3A%2F%2Fplaceimg.com%2F400%2F200%2Farch&w=3840&q=90 3840w"
+                        style={
+                          Object {
+                            "border": "none",
+                            "bottom": 0,
+                            "boxSizing": "border-box",
+                            "display": "block",
+                            "height": 0,
+                            "left": 0,
+                            "margin": "auto",
+                            "maxHeight": "100%",
+                            "maxWidth": "100%",
+                            "minHeight": "100%",
+                            "minWidth": "100%",
+                            "objectFit": undefined,
+                            "objectPosition": undefined,
+                            "padding": 0,
+                            "position": "absolute",
+                            "right": 0,
+                            "top": 0,
+                            "width": 0,
+                          }
+                        }
+                      />
+                    </noscript>
+                  </span>
+                </div>
+              </a>
+            </div>
+          </div>
+        </li>
+      </ul>
+    </div>
+    <div
+      className="css-1ktje31"
+    />
   </div>
 </div>
 `;

--- a/src/components/home-v1/ComponentWrapper/ComponentWrapper.tsx
+++ b/src/components/home-v1/ComponentWrapper/ComponentWrapper.tsx
@@ -39,6 +39,8 @@ function ComponentWrapper({
   gap,
   children,
 }: ComponentWrapperProps) {
+  // Check if button text is passed
+  const hasSeeMoreText = !!seeMore?.text;
   // @TODO fix for styling of seeMore button
   const seeMoreStyle = {
     color: textColor,
@@ -47,7 +49,6 @@ function ComponentWrapper({
     borderStyle: "solid",
     textTransform: "uppercase",
   };
-
   return (
     <Box
       bg={bg ? bg : ""}
@@ -113,13 +114,13 @@ function ComponentWrapper({
           {children}
         </GridItem>
         <GridItem gridColumn={{ md: 2 }} gridRow={{ md: 3 }} maxW="6xl">
-          <Box
-            maxWidth={{ base: "90vw", md: "75vw", lg: "90vw", xl: "85vw" }}
-            textAlign="center"
-            mt={{ base: 6 }}
-            mb={{ base: 7, md: 10, lg: 8 }}
-          >
-            {seeMore && (
+          {hasSeeMoreText && (
+            <Box
+              maxWidth={{ base: "90vw", md: "75vw", lg: "90vw", xl: "85vw" }}
+              textAlign="center"
+              mt={{ base: 6 }}
+              mb={{ base: 7, md: 10, lg: 8 }}
+            >
               <HomePageLink
                 id={`component-wrapper-seeMore-link-${id}`}
                 aria-label={`see more of ${title}`}
@@ -134,8 +135,8 @@ function ComponentWrapper({
               >
                 {seeMore.text}
               </HomePageLink>
-            )}
-          </Box>
+            </Box>
+          )}
         </GridItem>
       </Grid>
     </Box>

--- a/src/components/home-v1/ComponentWrapper/ComponentWrapper.tsx
+++ b/src/components/home-v1/ComponentWrapper/ComponentWrapper.tsx
@@ -49,6 +49,7 @@ function ComponentWrapper({
     borderStyle: "solid",
     textTransform: "uppercase",
   };
+
   return (
     <Box
       bg={bg ? bg : ""}

--- a/src/components/home-v1/Slideshow/__snapshots__/Slideshow.test.tsx.snap
+++ b/src/components/home-v1/Slideshow/__snapshots__/Slideshow.test.tsx.snap
@@ -730,11 +730,7 @@ exports[`Slideshow tests should render the UI snapshot correctly 1`] = `
     </div>
     <div
       className="css-1ktje31"
-    >
-      <div
-        className="css-i2lecr"
-      />
-    </div>
+    />
   </div>
 </div>
 `;


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-3378)

**This PR does the following:**
- Checks on the ComponentWrapper level if the seeMore button object contains a button text
- Conditionally renders the See More button only when button text was passed from Drupal
- Updates tests for Slideshow and CardGrid

### Review Steps:
- [ ] Pull in branch `git fetch origin RENO-3378/fix-see-more-button`
- [ ] Switch to relevant brach `git checkout RENO-3378/fix-see-more-button`
- [ ] Start a local build `npm run build && npm start`
- [ ] Confirm tests are passing `npm test`

### Front End Review Steps:
- [ ] View [Local Homepage](http://localhost:3000/)
- [ ] Confirm that New and Noteworthy section does not have a seeMore button outline
