### PR TITLE
RENO-3435: Add String Sanitization To GetColorway

### DIFF
--- a/src/utils/get-colorway.test.ts
+++ b/src/utils/get-colorway.test.ts
@@ -1,7 +1,7 @@
 import getColorway from "./get-colorway";
 
 describe("getColorway", () => {
-  it("should return correct colorway for /give slug.", () => {
+  it("should return the correct colorway for /give slug.", () => {
     const mockColorway = {
       primary: "brand.primary",
       secondary: "brand.secondary",
@@ -9,19 +9,51 @@ describe("getColorway", () => {
     expect(getColorway("/give")).toEqual(mockColorway);
   });
 
-  it("should return correct colorway for /research slug.", () => {
+  it("should return the correct colorway when a slug starting with '/research' or the string 'research' was passed.", () => {
     const mockColorway = {
       primary: "section.research.primary",
       secondary: "section.research.secondary",
     };
     expect(getColorway("/research")).toEqual(mockColorway);
+    expect(getColorway("/research/support")).toEqual(mockColorway);
+    expect(getColorway("/research/collections")).toEqual(mockColorway);
+    // Works when the string "research" is passed
+    expect(getColorway("research")).toEqual(mockColorway);
   });
 
-  it("should return correct colorway for a section.", () => {
+  it("should return the correct colorway when a slug starting with '/education' or the string 'education' was passed.", () => {
+    const mockColorway = {
+      primary: "#2540A4",
+      secondary: "#1D62E6",
+    };
+    expect(getColorway("/education")).toEqual(mockColorway);
+    expect(getColorway("/education/educators")).toEqual(mockColorway);
+    expect(getColorway("/education/kids")).toEqual(mockColorway);
+    expect(getColorway("/education/adults/career-employment")).toEqual(
+      mockColorway
+    );
+    // Works when the string "education" is passed
+    expect(getColorway("education")).toEqual(mockColorway);
+  });
+
+  it("should return the correct colorway for 'section_front'.", () => {
     const mockColorway = {
       primary: "brand.primary",
       secondary: "brand.secondary",
     };
     expect(getColorway("section_front")).toEqual(mockColorway);
+  });
+
+  it("should return the default colorway for any string that does not match a specific colorway.", () => {
+    const defaultColorway = getColorway("default");
+    const mockColorway = {
+      primary: "brand.primary",
+      secondary: "brand.secondary",
+    };
+    expect(defaultColorway).toEqual(mockColorway);
+    expect(getColorway("generic-section-front")).toEqual(mockColorway);
+    // Default values are returend if the prefix "/" is missing from a slug
+    expect(getColorway("research/collections")).toEqual(mockColorway);
+    expect(getColorway("education/educators")).toEqual(mockColorway);
   });
 });

--- a/src/utils/get-colorway.ts
+++ b/src/utils/get-colorway.ts
@@ -7,38 +7,34 @@ export type ColorwayMap = {
   [name: string]: Colorway;
 };
 
-// @TODO come up with better solution or naming convention. Section front parent sections share colors,
-// and currently its not possible to set a color once, you have to do it for each "parent" group
-// route, which is not ideal.
-// type SlugOrSection = "/give" | "/research" | "/education" | "section_front";
-
+// colorLabel can be any of the following:
 // slug - specific url
 // bundle - specific content type or other.
 // group - group of pages within a content type, mainly used for section_front
 
 export default function getColorway(colorwayLabel: string): Colorway {
+  let finalColorwayLabel: string;
+
+  // Sanatize passed slugs
+  if (colorwayLabel[0] === "/") {
+    finalColorwayLabel = colorwayLabel.replace(/^\//, "").split("/")[0];
+  } else {
+    finalColorwayLabel = colorwayLabel;
+  }
   const colorwayMap: ColorwayMap = {
     default: {
       primary: "brand.primary",
       secondary: "brand.secondary",
     },
-    "/give": {
+    give: {
       primary: "brand.primary",
       secondary: "brand.secondary",
     },
-    "/research": {
+    research: {
       primary: "section.research.primary",
       secondary: "section.research.secondary",
     },
-    "/research/support": {
-      primary: "section.research.primary",
-      secondary: "section.research.secondary",
-    },
-    "/education": {
-      primary: "#2540A4",
-      secondary: "#1D62E6",
-    },
-    "/education/educators": {
+    education: {
       primary: "#2540A4",
       secondary: "#1D62E6",
     },
@@ -48,5 +44,5 @@ export default function getColorway(colorwayLabel: string): Colorway {
     },
   };
 
-  return colorwayMap[colorwayLabel] || colorwayMap.default;
+  return colorwayMap[finalColorwayLabel] || colorwayMap.default;
 }

--- a/src/utils/get-colorway.ts
+++ b/src/utils/get-colorway.ts
@@ -15,7 +15,7 @@ export type ColorwayMap = {
 export default function getColorway(colorwayLabel: string): Colorway {
   let finalColorwayLabel: string;
 
-  // Sanatize passed slugs
+  // Sanitize passed slugs
   if (colorwayLabel[0] === "/") {
     finalColorwayLabel = colorwayLabel.replace(/^\//, "").split("/")[0];
   } else {


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-3435)

**This PR does the following:**
- Adds logic to sanitize slug strings
- Updates get-colorway tests

### Review Steps:
- [ ] Pull in branch `git fetch origin RENO-3435/refactor-get-colorway`
- [ ] Switch to relevant brach `git checkout RENO-3435/refactor-get-colorway`
- [ ] Start a local build `npm run build && npm start`
- [ ] Confirm tests are passing `npm test`
-> If Sideshow tests are failing run `npm install` to ensure the correct version of `testing-library/user-event` is installed

### Front End Review Steps:
- [ ] View [Section Front Give Page](http://localhost:3000/give)
- [ ] Confirm that the Hero colors are correct
- [ ] View [Section Front Research Page](http://localhost:3000/research)
- [ ] Confirm that the Hero colors are correct
- [ ] View [Section Front Support Page](http://localhost:3000/research/support)
- [ ] Confirm that the Hero colors are correct