### PR TITLE
RENO-3439: Fix Console Error For with-drupal-router test

### DIFF
--- a/src/apollo/with-drupal-router.test.js
+++ b/src/apollo/with-drupal-router.test.js
@@ -37,6 +37,7 @@ describe("with-drupal-router success states.", () => {
       id: "test-success-id",
       uuid: "test-success-uuid",
       redirect: null,
+      bundle: "test-success",
     };
 
     requestHandler.mockResolvedValueOnce({
@@ -70,6 +71,7 @@ describe("with-drupal-router success states.", () => {
         to: "/new-slug",
         status: "301",
       },
+      bundle: "test-redirect",
     };
 
     requestHandler.mockResolvedValueOnce({


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-3439)

**This PR does the following:**
- Adds bundle property to `decoupledRouterDataMock`

### Review Steps:
- [ ] Pull in branch `git fetch origin RENO-3439/fix-console-error `
- [ ] Switch to relevant brach `git checkout RENO-3439/fix-console-error `
- [ ] Run specific tests `npm test with-drupal-router`
- [ ] Confirm no errors in console
- [ ] Run all tests `npm test`
- [ ] Confirm all test pass

*Note: If Slideshow tests are failing run `npm i` to get the required version of `testing-library/user-event`
