### PR TITLE
RENO-3473: Update Jumbotron For Tablet And Mobile

### DIFF
--- a/src/components/shared/ContentComponents/Jumbotron.tsx
+++ b/src/components/shared/ContentComponents/Jumbotron.tsx
@@ -5,6 +5,7 @@ import {
   CardContent,
   Heading,
   Link,
+  useNYPLBreakpoints,
 } from "@nypl/design-system-react-components";
 import { default as SharedJumbotron } from "./../Jumbotron";
 import TextFormatted from "../TextFormatted";
@@ -33,6 +34,7 @@ export default function Jumbotron({
   secondaryImage,
   link,
 }: JumbotronProps) {
+  const { isLargerThanMedium } = useNYPLBreakpoints();
   return (
     <SharedJumbotron
       id={id}
@@ -62,8 +64,8 @@ export default function Jumbotron({
                   />
                 ),
                 size: "large",
-                // Positions the image to the right of the text.
-                isAtEnd: true,
+                // Positions the image to the right of the text (tablet/desktop) or on top of text (mobile).
+                isAtEnd: isLargerThanMedium,
               },
             })}
           >

--- a/src/components/shared/Jumbotron/Jumbotron.tsx
+++ b/src/components/shared/Jumbotron/Jumbotron.tsx
@@ -29,16 +29,17 @@ export default function Jumbotron({ id, image, overlay }: JumbotronProps) {
     <Box id={id} marginBottom="l">
       <Box
         backgroundImage={{
-          md: "none",
-          lg: backgroundImageSrcLg,
+          sm: "none",
+          //@TODO Should there be a transition for tablet?
+          md: backgroundImageSrcLg,
           "2xl": backgroundImageSrc2Xl,
         }}
         backgroundSize={{ sm: "100%", md: "cover" }}
         backgroundPosition={{ md: "center" }}
-        minHeight={{ lg: "464px" }}
-        marginBottom={{ sm: "m", md: "initial" }}
+        minHeight={{ md: "305px", lg: "464px" }}
+        marginBottom={{ sm: "s", md: "initial" }}
       >
-        <Box display={{ lg: "none" }}>
+        <Box display={{ md: "none" }}>
           <Image
             id={image.id}
             alt={image.alt}
@@ -59,8 +60,11 @@ export default function Jumbotron({ id, image, overlay }: JumbotronProps) {
         maxWidth="1240px"
         margin="0 auto"
         padding={{ sm: "s", md: "xl" }}
-        marginTop={{ lg: "-40px" }}
-        boxShadow="0px 4px 4px rgba(0, 0, 0, 0.25)"
+        marginTop={{ md: "-40px" }}
+        boxShadow={{ md: "0px 4px 4px rgba(0, 0, 0, 0.25)" }}
+        borderWidth={{ sm: "1px", md: "none" }}
+        borderColor="ui.gray.medium"
+        mx={{ sm: "s", xl: "auto" }}
       >
         {overlay}
       </Box>


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-3473)
[Figma Design](https://www.figma.com/file/Yo3bXT18Lz7946ixcEtte9/RENO-Section-Fronts?node-id=3278-90749&t=6pIggod5Y3Z00oIZ-0)

## **This PR does the following:**

-

### Review Steps:

- [ ] Pull in branch `git fetch origin RENO-3473/add-mobile/tablet-jumbotron-view`
- [ ] Switch to relevant brach `git checkout RENO-3473/add-mobile/tablet-jumbotron-view`
- [ ] Start a local build `npm run build && npm start`
- [ ] Confirm tests are passing `npm test`
- [ ] Confirm cypress tests are passing `npm run cypress` in new terminal

### Front End Review Steps:

- [ ] View [Educators](http://localhost:3000/education/educators)
- [ ] Confirm that mobile and tablet view match the Figma files
- [ ] View [Give](http://localhost:3000/give)
- [ ] Confirm that Give page view mobile and tablet is correct (Olivia)
