### PR TITLE
RENO-3451: Fix SectionFront Preview

### DIFF
--- a/src/apollo/server/datasources/DrupalApi.js
+++ b/src/apollo/server/datasources/DrupalApi.js
@@ -1,5 +1,6 @@
 import { HTTPCache, RESTDataSource } from "apollo-datasource-rest";
 import { toApolloError } from "apollo-server-errors";
+import getAccessToken from "../../../utils/getAccessToken";
 const { DRUPAL_API } = process.env;
 
 class DrupalApi extends RESTDataSource {
@@ -126,13 +127,27 @@ class DrupalApi extends RESTDataSource {
   }
 
   /* ---------- DECOUPLED DRUPAL ---------- */
-  async getDecoupledRouter(args) {
-    let apiPath = `/router/translate-path?path=${args.path}`;
-    try {
-      const response = await this.get(apiPath);
-      return response;
-    } catch (error) {
-      throw toApolloError(error);
+  async getDecoupledRouter({ path, isPreview = false } = args) {
+    let apiPath = `/router/translate-path?path=${path}`;
+    if (isPreview) {
+      try {
+        const accessToken = await getAccessToken();
+        const response = await this.get(apiPath, undefined, {
+          headers: {
+            Authorization: `Bearer ${accessToken?.access_token}`,
+          },
+        });
+        return response;
+      } catch (error) {
+        throw toApolloError(error);
+      }
+    } else {
+      try {
+        const response = await this.get(apiPath);
+        return response;
+      } catch (error) {
+        throw toApolloError(error);
+      }
     }
   }
 

--- a/src/apollo/server/datasources/drupal-json-api/DrupalJsonApi.ts
+++ b/src/apollo/server/datasources/drupal-json-api/DrupalJsonApi.ts
@@ -34,14 +34,6 @@ class DrupalJsonApi<TContext = any> extends RESTDataSource {
     }
   }
 
-  // @TODO this is currently not used.
-  async getDecoupledRouter(args: { path: string }) {
-    // Get resource url from path.
-    let apiPath = `/router/translate-path?path=${args.path}`;
-    const response = await this.get(apiPath);
-    return response;
-  }
-
   async getCollectionResource(
     apiPath: string,
     isPreview: boolean

--- a/src/apollo/server/type-defs/decoupledRouter.js
+++ b/src/apollo/server/type-defs/decoupledRouter.js
@@ -15,6 +15,6 @@ export const typeDefs = gql`
   }
 
   extend type Query {
-    decoupledRouter(path: String): DecoupledRouter
+    decoupledRouter(path: String, isPreview: Boolean): DecoupledRouter
   }
 `;

--- a/src/apollo/with-drupal-router.test.js
+++ b/src/apollo/with-drupal-router.test.js
@@ -102,20 +102,37 @@ describe("with-drupal-router success states.", () => {
       },
       preview: true,
       previewData: {
-        uuid: "slug-preview-uuid",
-        revisionId: "slug-preview-revision-id",
+        uuid: "test-preview-uuid",
+        revisionId: "test-preview-revision-id",
       },
+      bundle: "test-preview",
     };
 
-    const getStaticPropsMock = withDrupalRouter(async (context, props) => {
+    const decoupledRouterDataMock = {
+      id: "test-preview-id",
+      uuid: "test-preview-uuid",
+      preview: true,
+      previewData: {
+        uuid: "test-preview-uuid",
+        revisionId: "test-preview-revision-id",
+      },
+      redirect: null,
+      bundle: "test-preview",
+    };
+
+    requestHandler.mockResolvedValueOnce({
+      data: { decoupledRouter: decoupledRouterDataMock },
+    });
+
+    const getStaticPropsMock = withDrupalRouter(async (contextMock, props) => {
       return props;
     });
 
     const result = await getStaticPropsMock(contextMock);
 
     expect(result.isPreview).toEqual(true);
-    expect(result.uuid).toEqual("slug-preview-uuid");
-    expect(result.revisionId).toEqual("slug-preview-revision-id");
+    expect(result.uuid).toEqual("test-preview-uuid");
+    expect(result.revisionId).toEqual("test-preview-revision-id");
   });
 });
 

--- a/src/apollo/with-drupal-router.ts
+++ b/src/apollo/with-drupal-router.ts
@@ -131,9 +131,12 @@ export default function withDrupalRouter<
       },
     });
 
-    bundle = await decoupledRouterData?.data?.decoupledRouter?.bundle;
+    // Set the UUID for published pages
+    if (!isPreview) {
+      uuid = await decoupledRouterData?.data?.decoupledRouter?.uuid;
+    }
 
-    uuid = await decoupledRouterData?.data?.decoupledRouter?.uuid;
+    bundle = await decoupledRouterData?.data?.decoupledRouter?.bundle;
 
     // Handle the redirect if it exists.
     const redirect = await decoupledRouterData?.data?.decoupledRouter?.redirect;

--- a/src/apollo/with-drupal-router.ts
+++ b/src/apollo/with-drupal-router.ts
@@ -147,7 +147,6 @@ export default function withDrupalRouter<
         props: {},
       };
     }
-    // }
 
     const returnProps: WithDrupalRouterReturnProps = {
       uuid,

--- a/src/hooks/useDecoupledRouter.ts
+++ b/src/hooks/useDecoupledRouter.ts
@@ -3,8 +3,8 @@ import { NextRouter } from "next/router";
 const { NEXT_PUBLIC_DRUPAL_PREVIEW_SECRET } = process.env;
 
 export const DECOUPLED_ROUTER_QUERY = gql`
-  query DecoupledRouterQuery($path: String) {
-    decoupledRouter(path: $path) {
+  query DecoupledRouterQuery($path: String, $isPreview: Boolean) {
+    decoupledRouter(path: $path, isPreview: $isPreview) {
       id
       uuid
       redirect {
@@ -39,7 +39,6 @@ function useDecoupledRouter(nextRouter: NextRouter) {
     },
   });
   const uuid = decoupledRouterData?.decoupledRouter?.uuid;
-
   return {
     uuid: uuid,
     isPreview: isPreview,

--- a/src/pages/api/preview.ts
+++ b/src/pages/api/preview.ts
@@ -32,7 +32,7 @@ export default async function handler(
   });
 
   // Redirect to the path from the fetched route.
-  const previewUrl = `/${request?.query?.slug}?uuid=${request.query.uuid}&revision_id=${request.query.revision_id}`;
+  const previewUrl = `${request?.query?.slug}?uuid=${request.query.uuid}&revision_id=${request.query.revision_id}`;
   response.writeHead(307, { Location: previewUrl ?? "/" });
 
   return response.end();


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-3451)

## **This PR does the following:**

- Adds `isPreview` prop  to getDecoupledRouter to catch and handle preview request
- Removes unused getDecoupledRouter function from DrupalJsonApi.ts
- Updates withDrupalRouter to handle preview requests
- Updates withDrupalRouter preview test 

### Review Steps:

- [ ] Pull in branch `git fetch origin RENO-3451/section-front-preview-bug`
- [ ] Switch to relevant brach `git checkout RENO-3451/section-front-preview-bug`
- [ ] Change the DRUPAL_API in .env to point to `https://pr1050-nypl1.pantheonsite.io`
- [ ] Start a local build `npm run build && npm start`
- [ ] Confirm tests are passing `npm test`
- [ ] Confirm Cypress tests are passing by running `npm run cypress` in new terminal
* Note: Cypress text for next/prev page in /press is broken as of 03/23

### Front End Review Steps:

- [ ] Login to [Drupal MultiDev](https://pr1050-nypl1.pantheonsite.io/user/login?bypass)
- [ ] Go to preview the **unpublished** Support and Services Page
- [ ] Right click the "View Frontend" button and Copy Link address
- [ ] In new browser window paste the url and replace the base url with `localhost:3000` 
- [ ] Confirm that the Page renders
- [ ] Repeat with an **unpublished** blog post to confirm that the preview is still working
- [ ] Repeat with an **unpublished** press release to confirm that the preview is still working
- [ ] On Drupal publish the Support and Services Page
- [ ] Visit the [Support and Services Page](localhost:3000/research/support)
- [ ] Confirm the page is rendering 

