### PR TITLE
RENO-3507: Fix useDecoupledRouter Query

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "editor.formatOnSave": true,
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/src/apollo/server/datasources/drupal-json-api/DrupalJsonApi.ts
+++ b/src/apollo/server/datasources/drupal-json-api/DrupalJsonApi.ts
@@ -33,7 +33,7 @@ class DrupalJsonApi<TContext = any> extends RESTDataSource {
       return response.text();
     }
   }
-  
+
   async getCollectionResource(
     apiPath: string,
     isPreview: boolean

--- a/src/apollo/server/type-defs/shared.js
+++ b/src/apollo/server/type-defs/shared.js
@@ -129,7 +129,7 @@ export const typeDefs = gql`
   type Text {
     id: ID!
     type: String!
-    text: String
+    text: String!
     heading: String
   }
 

--- a/src/apollo/with-drupal-router.ts
+++ b/src/apollo/with-drupal-router.ts
@@ -59,7 +59,6 @@ export default function withDrupalRouter<
     let revisionId;
     let slug;
     let isPreview = false;
-    let bundle;
 
     // Handle different types of preview mode.
     const isNextPreview = !options?.customPreview;
@@ -136,7 +135,7 @@ export default function withDrupalRouter<
       uuid = await decoupledRouterData?.data?.decoupledRouter?.uuid;
     }
 
-    bundle = await decoupledRouterData?.data?.decoupledRouter?.bundle;
+    const bundle = await decoupledRouterData?.data?.decoupledRouter?.bundle;
 
     // Handle the redirect if it exists.
     const redirect = await decoupledRouterData?.data?.decoupledRouter?.redirect;

--- a/src/components/shared/Link/NextChakraLink.tsx
+++ b/src/components/shared/Link/NextChakraLink.tsx
@@ -29,7 +29,7 @@ export const NextChakraLink = ({
       replace={replace}
       scroll={scroll}
       shallow={shallow}
-      prefetch={prefetch}
+      {...(prefetch === false && { prefetch: prefetch })}
     >
       <ChakraLink
         sx={{

--- a/src/components/shared/Link/NextDsLink.tsx
+++ b/src/components/shared/Link/NextDsLink.tsx
@@ -11,7 +11,11 @@ interface LinkProps {
 // @TODO Replace Box with DS Link eventually.
 function NextDsLink({ children, href, prefetch = true }: LinkProps) {
   return (
-    <NextLink href={href} prefetch={prefetch} passHref>
+    <NextLink
+      href={href}
+      {...(prefetch === false && { prefetch: prefetch })}
+      passHref
+    >
       <Box
         as="a"
         sx={{

--- a/src/hooks/useDecoupledRouter.ts
+++ b/src/hooks/useDecoupledRouter.ts
@@ -39,6 +39,7 @@ function useDecoupledRouter(nextRouter: NextRouter) {
   const { data: decoupledRouterData } = useQuery(DECOUPLED_ROUTER_QUERY, {
     variables: {
       path: slug,
+      isPreview: isPreview,
     },
   });
   const uuid = decoupledRouterData?.decoupledRouter?.uuid;

--- a/src/hooks/useDecoupledRouter.ts
+++ b/src/hooks/useDecoupledRouter.ts
@@ -17,13 +17,13 @@ export const DECOUPLED_ROUTER_QUERY = gql`
   }
 `;
 
-function useDecoupledRouter(nextRouter: NextRouter) {
-  // Preview mode.
+export default function useDecoupledRouter(nextRouter: NextRouter) {
   const isPreview =
     nextRouter.query.preview_secret === NEXT_PUBLIC_DRUPAL_PREVIEW_SECRET &&
     nextRouter.query.uuid
       ? true
       : false;
+
   // Set the uuid for preview mode.
   if (isPreview) {
     return {
@@ -31,10 +31,11 @@ function useDecoupledRouter(nextRouter: NextRouter) {
       uuid: nextRouter.query.uuid,
     };
   }
+
   // Not preview mode, so run the query to resolve a uuid from a slug.
   const slug = nextRouter.asPath;
-  // @TODO decide the order of execution, had to unable the rule because the query is running conditionally
-  // not on every render
+  // @TODO decide the order of execution, had to disable eslint rule because the query is
+  // running conditionally not on every render.
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const { data: decoupledRouterData } = useQuery(DECOUPLED_ROUTER_QUERY, {
     variables: {
@@ -42,11 +43,11 @@ function useDecoupledRouter(nextRouter: NextRouter) {
       isPreview: isPreview,
     },
   });
+
   const uuid = decoupledRouterData?.decoupledRouter?.uuid;
+
   return {
     uuid: uuid,
     isPreview: isPreview,
   };
 }
-
-export default useDecoupledRouter;


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-3507)

## **This PR does the following:**

- Adds isPreview to the query in useDecoupledRouter
- Fixes some formatting
- Updates the props in NextsLink to fix *NextLink prop deprecated* message 

### Review Steps:

- [ ] Pull in branch `git fetch origin RENO-3507/fix-useDecoupledRouter-hook
- [ ] Switch to relevant brach `git checkout RENO-3507/fix-useDecoupledRouter-hook`
- [ ] Start a local build `npm run build && npm start`
- [ ] Confirm Unit tests are passing `npm test`
- [ ] Confirm Cypress tests are passing `npm run cypress` in separat terminal

### Front End Review Steps:

- [ ] View [Blog page](http://localhost:3000/blog)
- [ ] Inspect site and choose Network tab
- [ ] Navigate to a blog post
- [ ] Upon reload page no new query call should be made
