### PR TITLE
RENO-3536: Wires Up Breadcrumbs from Drupal JSON API.

### DIFF
--- a/src/apollo/server/resolvers/sectionFrontResolver.js
+++ b/src/apollo/server/resolvers/sectionFrontResolver.js
@@ -45,6 +45,7 @@ const sectionFrontResolver = {
       sectionFront.field_ers_media_image.data !== null
         ? resolveImage(sectionFront.field_ers_media_image)
         : null,
+    breadcrumbs: (sectionFront) => sectionFront.breadcrumbs,
     featuredContent: (sectionFront, _, __, info) => {
       const resolveInfo = parseResolveInfo(info);
       const typesInQuery = Object.keys(resolveInfo.fieldsByTypeName);

--- a/src/apollo/server/type-defs/sectionFront.js
+++ b/src/apollo/server/type-defs/sectionFront.js
@@ -6,6 +6,7 @@ export const typeDefs = gql`
     title: String!
     description: String
     image: Image
+    breadcrumbs: [BreadcrumbsItem]
     featuredContent: [SectionFrontFeaturedContent]
     mainContent: [SectionFrontMainContent]
     colorway: Colorway

--- a/src/apollo/server/type-defs/shared.js
+++ b/src/apollo/server/type-defs/shared.js
@@ -278,4 +278,10 @@ export const typeDefs = gql`
     description: String
     items: [ButtonLink]
   }
+
+  type BreadcrumbsItem {
+    id: ID!
+    title: String!
+    url: String!
+  }
 `;

--- a/src/components/section-fronts/SectionFrontPage/SectionFrontPage.tsx
+++ b/src/components/section-fronts/SectionFrontPage/SectionFrontPage.tsx
@@ -2,13 +2,13 @@ import * as React from "react";
 // Apollo
 import { gql, useQuery } from "@apollo/client";
 // Components
-import PageContainer from "../../shared/layouts/PageContainer";
+import PageContainer, {
+  BreadcrumbsItem,
+} from "../../shared/layouts/PageContainer";
+
 import { Box, Heading, Hero } from "@nypl/design-system-react-components";
 import Components from "./../../shared/ContentComponents/getReactComponent";
 import PreviewModeNotification from "../../shared/PreviewModeNotification";
-import getBreadcrumbsTrail from "../../../utils/get-breadcrumbs-trail";
-// Content + config
-const { NEXT_PUBLIC_NYPL_DOMAIN } = process.env;
 
 export const SECTION_FRONT_QUERY = gql`
   query SectionFrontQuery($id: String, $revisionId: String, $preview: Boolean) {
@@ -28,6 +28,13 @@ export const SECTION_FRONT_QUERY = gql`
           id
           label
           uri
+        }
+      }
+      breadcrumbs {
+        ... on BreadcrumbsItem {
+          id
+          title
+          url
         }
       }
       featuredContent {
@@ -189,7 +196,6 @@ interface SectionFrontPageProps {
 
 export default function SectionFrontPage({
   uuid,
-  slug,
   isPreview,
   revisionId,
 }: SectionFrontPageProps) {
@@ -223,13 +229,11 @@ export default function SectionFrontPage({
         description: sectionFront.description,
         imageUrl: sectionFront.image?.uri,
       }}
-      breadcrumbs={[
-        {
-          text: "Home",
-          url: `${NEXT_PUBLIC_NYPL_DOMAIN}`,
-        },
-        ...getBreadcrumbsTrail(slug),
-      ]}
+      breadcrumbs={sectionFront.breadcrumbs.map(
+        (breadcrumbsItem: any): BreadcrumbsItem => {
+          return { text: breadcrumbsItem.title, url: breadcrumbsItem.url };
+        }
+      )}
       breadcrumbsColor={sectionFront.colorway.secondary}
       wrapperClass="nypl--section-fronts"
       contentHeader={

--- a/src/components/section-fronts/SectionFrontPage/SectionFrontPage.tsx
+++ b/src/components/section-fronts/SectionFrontPage/SectionFrontPage.tsx
@@ -31,11 +31,9 @@ export const SECTION_FRONT_QUERY = gql`
         }
       }
       breadcrumbs {
-        ... on BreadcrumbsItem {
-          id
-          title
-          url
-        }
+        id
+        title
+        url
       }
       featuredContent {
         ... on Donation {
@@ -229,11 +227,21 @@ export default function SectionFrontPage({
         description: sectionFront.description,
         imageUrl: sectionFront.image?.uri,
       }}
-      breadcrumbs={sectionFront.breadcrumbs.map(
-        (breadcrumbsItem: any): BreadcrumbsItem => {
-          return { text: breadcrumbsItem.title, url: breadcrumbsItem.url };
-        }
-      )}
+      breadcrumbs={
+        sectionFront.breadcrumbs &&
+        sectionFront.breadcrumbs.map(
+          (breadcrumbsItem: {
+            id: string;
+            title: string;
+            url: string;
+          }): BreadcrumbsItem => {
+            return {
+              text: breadcrumbsItem.title,
+              url: breadcrumbsItem.url,
+            };
+          }
+        )
+      }
       breadcrumbsColor={sectionFront.colorway.secondary}
       wrapperClass="nypl--section-fronts"
       contentHeader={


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-3536)


## **This PR does the following:**

- Adds schema type for breadcrumbs
- Adds breadcrumbs to sectionfront resolver
- Passes sectionFront.breadcrumbs.data to page container component

### Previews
**Backend**
https://pr1057-nypl1.pantheonsite.io
**Frontend**
https://scout-git-reno-3536-wire-up-breadcrumb-data-nypl.vercel.app

### Review Steps:

- [ ] Pull in branch `git fetch origin RENO-3536/wire-up-breadcrumb-data`
- [ ] Switch to relevant brach `git checkout RENO-3536/wire-up-breadcrumb-data`
- [ ] Change .env line 3: `DRUPAL_API=https://pr1057-nypl1.pantheonsite.io`
- [ ] Start a local build `npm run build && npm start`
- [ ] Confirm tests are passing `npm test`

### Front End Review Steps:

- [ ] View [Example](http://localhost:3000/eduction/educators)
