### PR TITLE
RENO-3550: Remove status field and related code

### DIFF
--- a/src/apollo/server/resolvers/sectionFrontResolver.js
+++ b/src/apollo/server/resolvers/sectionFrontResolver.js
@@ -82,7 +82,7 @@ const sectionFrontResolver = {
       const resolveInfo = parseResolveInfo(info);
       const typesInQuery = Object.keys(resolveInfo.fieldsByTypeName);
       const bottomContent =
-        sectionFront.field_erm_bottom_content?.data.length === 0
+        sectionFront.field_erm_bottom_content.data?.length === 0
           ? null
           : resolveDrupalParagraphs(
               sectionFront.field_erm_bottom_content,

--- a/src/apollo/server/resolvers/sectionFrontResolver.js
+++ b/src/apollo/server/resolvers/sectionFrontResolver.js
@@ -82,7 +82,7 @@ const sectionFrontResolver = {
       const resolveInfo = parseResolveInfo(info);
       const typesInQuery = Object.keys(resolveInfo.fieldsByTypeName);
       const bottomContent =
-        sectionFront.field_erm_bottom_content.data === null
+        sectionFront.field_erm_bottom_content?.data.length === 0
           ? null
           : resolveDrupalParagraphs(
               sectionFront.field_erm_bottom_content,

--- a/src/apollo/server/resolvers/utils/resolveDrupalParagraphs.ts
+++ b/src/apollo/server/resolvers/utils/resolveDrupalParagraphs.ts
@@ -655,13 +655,13 @@ export default function resolveDrupalParagraphs(
         break;
     }
 
-    // Add published status for paragraph entities, if not set, set to false.
-    // We can assume that if the status property is missing from the object,
-    // then the paragraph is unpublished, and an unautheticated requested was made,
-    // which causes the status property to be omitted from the response.
     if (paragraphComponent) {
-      paragraphComponent.status = item.status ? item.status : false;
-      items.push(paragraphComponent);
+      // Unpublished paragraphs will not have a status property for unauthorized api requests.
+      const paragraphComponentStatus = item.status ? item.status : false;
+      // Only add the paragraph component to the array of items if it is published.
+      if (paragraphComponentStatus) {
+        items.push(paragraphComponent);
+      }
     }
   });
   return items;

--- a/src/apollo/server/type-defs/shared.js
+++ b/src/apollo/server/type-defs/shared.js
@@ -243,15 +243,6 @@ export const typeDefs = gql`
     url: String!
   }
 
-  type Colorway {
-    primary: String
-    secondary: String
-  }
-
-  type Query {
-    _empty: String
-  }
-
   type EmailSubscription {
     id: ID!
     status: Boolean!
@@ -279,12 +270,6 @@ export const typeDefs = gql`
     items: [ButtonLink]
   }
 
-  type BreadcrumbsItem {
-    id: ID!
-    title: String!
-    url: String!
-  }
-
   type DonorCredit {
     id: ID!
     status: Boolean!
@@ -292,5 +277,20 @@ export const typeDefs = gql`
     heading: String
     description: String!
     showBorder: Boolean!
+  }
+
+  type BreadcrumbsItem {
+    id: ID!
+    title: String!
+    url: String!
+  }
+
+  type Colorway {
+    primary: String
+    secondary: String
+  }
+
+  type Query {
+    _empty: String
   }
 `;

--- a/src/apollo/server/type-defs/shared.js
+++ b/src/apollo/server/type-defs/shared.js
@@ -76,7 +76,6 @@ export const typeDefs = gql`
 
   type TextWithImage {
     id: ID!
-    status: Boolean!
     type: String!
     heading: String
     text: String!
@@ -87,7 +86,6 @@ export const typeDefs = gql`
 
   type Video {
     id: ID!
-    status: Boolean!
     type: String!
     heading: String
     description: String
@@ -98,7 +96,6 @@ export const typeDefs = gql`
 
   type AudioEmbed {
     id: ID!
-    status: Boolean!
     type: String!
     heading: String
     description: String
@@ -110,14 +107,12 @@ export const typeDefs = gql`
 
   type SocialEmbed {
     id: ID!
-    status: Boolean!
     type: String!
     embedCode: String!
   }
 
   type GoogleMapEmbed {
     id: ID!
-    status: Boolean!
     type: String!
     embedCode: String!
     accessibleDescription: String!
@@ -125,7 +120,6 @@ export const typeDefs = gql`
 
   type Slideshow {
     id: ID!
-    status: Boolean!
     type: String!
     heading: String
     description: String
@@ -134,7 +128,6 @@ export const typeDefs = gql`
 
   type Text {
     id: ID!
-    status: Boolean!
     type: String!
     text: String!
     heading: String
@@ -142,7 +135,6 @@ export const typeDefs = gql`
 
   type ImageComponent {
     id: ID!
-    status: Boolean!
     type: String!
     image: Image
     caption: String
@@ -152,7 +144,6 @@ export const typeDefs = gql`
 
   type CardList {
     id: ID!
-    status: Boolean!
     type: String!
     title: String
     description: String
@@ -169,7 +160,6 @@ export const typeDefs = gql`
 
   type CatalogList {
     id: ID!
-    status: Boolean!
     type: String!
     heading: String
     description: String
@@ -186,7 +176,6 @@ export const typeDefs = gql`
 
   type Donation {
     id: ID!
-    status: Boolean!
     type: String!
     title: String
     description: String
@@ -198,7 +187,6 @@ export const typeDefs = gql`
 
   type ExternalSearch {
     id: ID!
-    status: Boolean!
     type: String!
     title: String
     description: String
@@ -209,7 +197,6 @@ export const typeDefs = gql`
 
   type CardGrid {
     id: ID!
-    status: Boolean!
     type: String!
     title: String
     description: String
@@ -228,7 +215,6 @@ export const typeDefs = gql`
 
   type Jumbotron {
     id: ID!
-    status: Boolean!
     type: String!
     title: String
     description: String
@@ -245,7 +231,6 @@ export const typeDefs = gql`
 
   type EmailSubscription {
     id: ID!
-    status: Boolean!
     type: String!
     heading: String
     description: String
@@ -263,7 +248,6 @@ export const typeDefs = gql`
 
   type ButtonLinks {
     id: ID!
-    status: Boolean!
     type: String!
     heading: String
     description: String
@@ -272,7 +256,6 @@ export const typeDefs = gql`
 
   type DonorCredit {
     id: ID!
-    status: Boolean!
     type: String!
     heading: String
     description: String!

--- a/src/components/section-fronts/SectionFrontPage/SectionFrontPage.tsx
+++ b/src/components/section-fronts/SectionFrontPage/SectionFrontPage.tsx
@@ -39,7 +39,6 @@ export const SECTION_FRONT_QUERY = gql`
         ... on Donation {
           __typename
           id
-          status
           type
           title
           description
@@ -62,7 +61,6 @@ export const SECTION_FRONT_QUERY = gql`
         ... on Jumbotron {
           __typename
           id
-          status
           type
           title
           description
@@ -101,7 +99,6 @@ export const SECTION_FRONT_QUERY = gql`
         ... on CardGrid {
           __typename
           id
-          status
           type
           title
           description
@@ -131,7 +128,6 @@ export const SECTION_FRONT_QUERY = gql`
         ... on ExternalSearch {
           __typename
           id
-          status
           type
           title
           description
@@ -144,7 +140,6 @@ export const SECTION_FRONT_QUERY = gql`
         ... on EmailSubscription {
           __typename
           id
-          status
           type
           heading
           description
@@ -158,7 +153,6 @@ export const SECTION_FRONT_QUERY = gql`
         ... on ButtonLinks {
           __typename
           id
-          status
           type
           heading
           description
@@ -175,7 +169,6 @@ export const SECTION_FRONT_QUERY = gql`
         ... on Text {
           __typename
           id
-          status
           type
           heading
           text

--- a/src/components/shared/ContentComponents/getReactComponent.tsx
+++ b/src/components/shared/ContentComponents/getReactComponent.tsx
@@ -49,11 +49,6 @@ export default function mapContentComponentToReactComponent(
   contentComponent: ContentComponentObject
 ) {
   if (typeof Components[contentComponent["__typename"]] !== "undefined") {
-    // If the status field is false, don't render the component at all.
-    if (contentComponent.status === false) {
-      return null;
-    }
-
     return React.createElement(Components[contentComponent["__typename"]], {
       key: contentComponent.id,
       // If the component is EmailSubscription add colorway values as bgColor.


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-3550)

## **This PR does the following:**

- [x] Remove status field from all component type definitions
- [x] Remove status check from `mapContentComponentToReactComponent()`
- [x] Remove status field from section front gql queries
- [x] Replace logic in `resolveDrupalParagraphs()` to not add items to the array if status field is undefined.

### Review Steps:

- [ ] Pull in branch `git fetch origin RENO-****/branch-name`
- [ ] Switch to relevant brach `git checkout RENO-****/branch-name`
- [ ] Start a local build `npm run build && npm start`
- [ ] Confirm tests are passing `npm test`

### Front End Review Steps:

- [ ] View [Example](http://localhost:3000/)
