### PR TITLE
RENO-3537: Add Remaining Colorways

### DIFF
--- a/cypress/support/utils/testSearch.ts
+++ b/cypress/support/utils/testSearch.ts
@@ -13,7 +13,7 @@ export function search(term: string, options: SearchOptions) {
   if (autoSuggest && autoSuggestDownArrowCount) {
     let downArrowsString = "";
     for (let i = 0; i < autoSuggestDownArrowCount; i++) {
-      downArrowsString += "{downarrow}";
+      downArrowsString += "{downArrow}";
     }
 
     typedString = `${term}${downArrowsString}`;

--- a/src/utils/get-colorway.test.ts
+++ b/src/utils/get-colorway.test.ts
@@ -23,8 +23,8 @@ describe("getColorway", () => {
 
   it("should return the correct colorway when a slug starting with '/education' or the string 'education' was passed.", () => {
     const mockColorway = {
-      primary: "#1D62E6",
-      secondary: "#2540A4",
+      primary: "section.education.primary",
+      secondary: "section.education.secondary",
     };
     expect(getColorway("/education")).toEqual(mockColorway);
     expect(getColorway("/education/educators")).toEqual(mockColorway);

--- a/src/utils/get-colorway.ts
+++ b/src/utils/get-colorway.ts
@@ -26,17 +26,33 @@ export default function getColorway(colorwayLabel: string): Colorway {
       primary: "brand.primary",
       secondary: "brand.secondary",
     },
+    "books-music-movies": {
+      primary: "#C60917",
+      secondary: "#760000",
+    },
+    connect: {
+      primary: "#737373",
+      secondary: "#565656",
+    },
+    education: {
+      primary: "section.education.primary",
+      secondary: "section.education.secondary",
+    },
+    events: {
+      primary: "section.whats-on.primary",
+      secondary: "section.whats-on.secondary",
+    },
     give: {
       primary: "brand.primary",
       secondary: "brand.secondary",
     },
+    "get-help": {
+      primary: "#737373",
+      secondary: "#565656",
+    },
     research: {
       primary: "section.research.primary",
       secondary: "section.research.secondary",
-    },
-    education: {
-      primary: "#1D62E6",
-      secondary: "#2540A4",
     },
     section_front: {
       primary: "brand.primary",

--- a/src/utils/get-colorway.ts
+++ b/src/utils/get-colorway.ts
@@ -22,22 +22,22 @@ export default function getColorway(colorwayLabel: string): Colorway {
     finalColorwayLabel = colorwayLabel;
   }
   const colorwayMap: ColorwayMap = {
-    default: {
+    // Red: primary: "#C60917",secondary: "#760000"
+    "books-music-movies": {
       primary: "brand.primary",
       secondary: "brand.secondary",
     },
-    "books-music-movies": {
-      primary: "#C60917",
-      secondary: "#760000",
-    },
+    // Gray
     connect: {
       primary: "#737373",
       secondary: "#565656",
     },
+    // Blue: primary: "#1D62E6",secondary: "#2540A4"
     education: {
       primary: "section.education.primary",
       secondary: "section.education.secondary",
     },
+    // Black: primary: "#242424",secondary: "#000"
     events: {
       primary: "section.whats-on.primary",
       secondary: "section.whats-on.secondary",
@@ -46,15 +46,21 @@ export default function getColorway(colorwayLabel: string): Colorway {
       primary: "brand.primary",
       secondary: "brand.secondary",
     },
+    // Gray
     "get-help": {
       primary: "#737373",
       secondary: "#565656",
     },
+    // Blue-Green: primary: "#00838A",secondary: "#006166"
     research: {
       primary: "section.research.primary",
       secondary: "section.research.secondary",
     },
     section_front: {
+      primary: "brand.primary",
+      secondary: "brand.secondary",
+    },
+    default: {
       primary: "brand.primary",
       secondary: "brand.secondary",
     },


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-3537)
[Colorway List](https://docs.google.com/spreadsheets/d/1mlN7_XhB3Oc4XvU2kBaRYkco3KtnjtqjjpRgTC3vyjg/edit#gid=0)

## **This PR does the following:**

- Adds remaining colorway values to lookup table
- Uses nypl color values where possible
- Updates colorway tests 

### Review Steps:

- [ ] Pull in branch `git fetch origin RENO-3537/set-remaining-colorways`
- [ ] Switch to relevant brach `git checkout RENO-3537/set-remaining-colorways`
- [ ] Start a local build `npm run build && npm start`
- [ ] Confirm Unit tests are passing `npm test`
- [ ] Confirm Cypress tests are passing `npm run cypress` in new terminal

### Front End Review Steps:
Test colorways of all available section front pages:
* use qa-drupal data

- [ ] View [Donation](http://localhost:3000/give)
- [ ] View [Research](http://localhost:3000/research)
- [ ] View [Educator](http://localhost:3000/education/educators)
- [ ] View [Get Help](http://localhost:3000/get-help)
- [ ] View [Connect](http://localhost:3000/connect)
- [ ] View [Events](http://localhost:3000//events/author-talks-conversations)


