### PR TITLE
RENO-3546: Add Button Links to Card Component

### DIFF
--- a/src/apollo/server/resolvers/sectionFrontResolver.js
+++ b/src/apollo/server/resolvers/sectionFrontResolver.js
@@ -18,7 +18,7 @@ const sectionFrontResolver = {
         // Link Card List
         "field_main_content.field_erm_link_cards",
         "field_main_content.field_erm_link_cards.field_ers_image.field_media_image",
-        "field_main_content.field_erm_link_cards.field_erm_button_links",
+        "field_main_content.field_erm_link_cards.field_erm_card_button_links",
         // Button Links
         "field_main_content.field_erm_button_links",
         // Bottom Content

--- a/src/apollo/server/resolvers/sectionFrontResolver.js
+++ b/src/apollo/server/resolvers/sectionFrontResolver.js
@@ -18,6 +18,7 @@ const sectionFrontResolver = {
         // Link Card List
         "field_main_content.field_erm_link_cards",
         "field_main_content.field_erm_link_cards.field_ers_image.field_media_image",
+        "field_main_content.field_erm_link_cards.field_erm_button_links",
         // Button Links
         "field_main_content.field_erm_button_links",
         // Bottom Content

--- a/src/apollo/server/resolvers/utils/resolveDrupalParagraphs.ts
+++ b/src/apollo/server/resolvers/utils/resolveDrupalParagraphs.ts
@@ -369,6 +369,23 @@ export default function resolveDrupalParagraphs(
         const cardItems: ResolvedParagraph[] = [];
         Array.isArray(item.field_erm_link_cards) &&
           item.field_erm_link_cards.map((cardItem: any) => {
+            // Get the button links.
+            const buttonLinks: ResolvedParagraph[] = [];
+
+            cardItem.field_erm_button_links.data !== null &&
+              Array.isArray(cardItem.field_erm_button_links) &&
+              cardItem.field_erm_button_links.map((buttonLink: any) => {
+                buttonLinks.push({
+                  id: buttonLink.id,
+                  icon: buttonLink.field_lts_icon,
+                  link: {
+                    title: buttonLink.field_ls_link.title,
+                    uri: buttonLink.field_ls_link.uri,
+                    url: buttonLink.field_ls_link.url,
+                  },
+                });
+              });
+
             cardItems.push({
               id: cardItem.id,
               title: cardItem.field_ts_heading,
@@ -380,8 +397,10 @@ export default function resolveDrupalParagraphs(
                 cardItem.field_ers_image.data === null
                   ? null
                   : resolveImage(cardItem.field_ers_image),
+              buttonLinks: buttonLinks,
             });
           });
+
         paragraphComponent = {
           id: item.id,
           type: paragraphTypeName,

--- a/src/apollo/server/resolvers/utils/resolveDrupalParagraphs.ts
+++ b/src/apollo/server/resolvers/utils/resolveDrupalParagraphs.ts
@@ -372,9 +372,9 @@ export default function resolveDrupalParagraphs(
             // Get the button links.
             const buttonLinks: ResolvedParagraph[] = [];
 
-            cardItem.field_erm_button_links.data !== null &&
-              Array.isArray(cardItem.field_erm_button_links) &&
-              cardItem.field_erm_button_links.map((buttonLink: any) => {
+            cardItem.field_erm_card_button_links.data !== null &&
+              Array.isArray(cardItem.field_erm_card_button_links) &&
+              cardItem.field_erm_card_button_links.map((buttonLink: any) => {
                 buttonLinks.push({
                   id: buttonLink.id,
                   icon: buttonLink.field_lts_icon,

--- a/src/apollo/server/type-defs/shared.js
+++ b/src/apollo/server/type-defs/shared.js
@@ -211,6 +211,7 @@ export const typeDefs = gql`
     description: String
     image: Image
     link: String
+    buttonLinks: [ButtonLink]
   }
 
   type Jumbotron {

--- a/src/components/section-fronts/SectionFrontPage/SectionFrontPage.tsx
+++ b/src/components/section-fronts/SectionFrontPage/SectionFrontPage.tsx
@@ -123,6 +123,15 @@ export const SECTION_FRONT_QUERY = gql`
                 uri
               }
             }
+            buttonLinks {
+              id
+              icon
+              link {
+                title
+                uri
+                url
+              }
+            }
           }
         }
         ... on ExternalSearch {

--- a/src/components/shared/ButtonLink/ButtonLink.tsx
+++ b/src/components/shared/ButtonLink/ButtonLink.tsx
@@ -22,7 +22,10 @@ const IconTable: Record<string, IconNames> = {
 };
 
 export default function ButtonLink({ id, link, icon }: ButtonLinkProps) {
-  if (icon === "apple_app_store" || icon === "google_play") {
+  const isAppStoreIcon =
+    icon === "apple_app_store" || icon === "google_play" ? true : false;
+
+  if (isAppStoreIcon) {
     const iconName =
       icon === "apple_app_store" ? "appleAppStoreBlack" : "googlePlayBlack";
 
@@ -33,6 +36,7 @@ export default function ButtonLink({ id, link, icon }: ButtonLinkProps) {
           id="logo-id"
           name={iconName}
           size="small"
+          // Google play logo is not the same height as apple app store logo.
           {...(icon === "google_play" && {
             sx: {
               maxWidth: "185px",

--- a/src/components/shared/ButtonLink/ButtonLink.tsx
+++ b/src/components/shared/ButtonLink/ButtonLink.tsx
@@ -1,0 +1,90 @@
+import * as React from "react";
+import {
+  Box,
+  Link,
+  Icon,
+  IconNames,
+  Logo,
+} from "@nypl/design-system-react-components";
+
+export type ButtonLinkProps = {
+  id: string;
+  link: { title: string; url: string; uri: string };
+  icon: string;
+};
+
+// Lookup table to match drupal strings to the corresponding DS IconNames
+const IconTable: Record<string, IconNames> = {
+  facebook: "legacySocialFacebook",
+  instagram: "socialInstagram",
+  twitter: "socialTwitter",
+  file_type_doc: "fileTypeDoc",
+};
+
+export default function ButtonLink({ id, link, icon }: ButtonLinkProps) {
+  if (icon === "apple_app_store" || icon === "google_play") {
+    const iconName =
+      icon === "apple_app_store" ? "appleAppStoreBlack" : "googlePlayBlack";
+
+    return (
+      <Link id={`link-${id}`} href={link.url} type="action">
+        <Logo
+          decorative
+          id="logo-id"
+          name={iconName}
+          size="small"
+          {...(icon === "google_play" && {
+            sx: {
+              maxWidth: "185px",
+            },
+          })}
+        />
+      </Link>
+    );
+  }
+
+  return (
+    <Box
+      id={`button-link-${id}`}
+      key={id}
+      as="li"
+      listStyleType="none"
+      w={{ sm: "full", md: "fit-content" }}
+    >
+      {/* @TODO once we are updating the DS version,
+        replace custome style with type="buttonSecondary"
+      */}
+      <Link
+        id={`link-${id}`}
+        href={link.url}
+        type="action"
+        w="full"
+        py="xs"
+        px="s"
+        textDecor="none"
+        color="ui.link.primary"
+        bg="transparent"
+        borderStyle="solid"
+        borderWidth="1px"
+        borderColor="ui.link.primary"
+        _hover={{
+          bg: "rgb(5, 118, 211,0.05 )",
+          borderColor: "ui.link.secondary",
+          color: "ui.link.secondary",
+          textDecor: "none",
+          svg: {
+            color: "ui.link.secondary",
+          },
+        }}
+      >
+        <Icon
+          name={IconTable[icon]}
+          size="small"
+          align="left"
+          color="ui.link.primary"
+        />
+        {link.title}
+      </Link>
+    </Box>
+  );
+}

--- a/src/components/shared/ButtonLink/index.ts
+++ b/src/components/shared/ButtonLink/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ButtonLink";

--- a/src/components/shared/CardGrid/Card.tsx
+++ b/src/components/shared/CardGrid/Card.tsx
@@ -25,7 +25,7 @@ export interface CardProps {
   /** An optional image component that can be passed to the card. */
   image?: JSX.Element;
   /** An optional set of button links. */
-  buttonLinks?: any;
+  buttonLinks?: ButtonLinkType[];
   /** Optional value to render the layout in a row or column. */
   layout?: LayoutTypes;
   /** Optional value to control the alignment of the text and elements. */
@@ -41,7 +41,7 @@ export default function Card({
   description,
   href,
   image,
-  buttonLinks = null,
+  buttonLinks,
   layout,
   isCentered,
   isBordered = false,

--- a/src/components/shared/CardGrid/Card.tsx
+++ b/src/components/shared/CardGrid/Card.tsx
@@ -58,10 +58,14 @@ export default function Card({
       isCentered={isCentered}
       layout={layout}
       isBordered={isBordered}
-      sx={{
-        // Override the card-body width to 100% to allow for proper centering of buttons.
-        ".card-body": { width: "100%" },
-      }}
+      // Override the card-body width for column layout with button links.
+      {...(layout === "column" &&
+        buttonLinks && {
+          sx: {
+            // Override the card-body width to 100% to allow for proper centering of buttons.
+            ".card-body": { width: "100%" },
+          },
+        })}
     >
       <CardHeading level="three">
         {href && <Link href={href}>{heading}</Link>}

--- a/src/components/shared/CardGrid/Card.tsx
+++ b/src/components/shared/CardGrid/Card.tsx
@@ -58,6 +58,10 @@ export default function Card({
       isCentered={isCentered}
       layout={layout}
       isBordered={isBordered}
+      sx={{
+        // Override the card-body width to 100% to allow for proper centering of buttons.
+        ".card-body": { width: "100%" },
+      }}
     >
       <CardHeading level="three">
         {href && <Link href={href}>{heading}</Link>}

--- a/src/components/shared/CardGrid/Card.tsx
+++ b/src/components/shared/CardGrid/Card.tsx
@@ -4,9 +4,12 @@ import {
   Card as DsCard,
   CardContent,
   CardHeading,
+  Flex,
   LayoutTypes,
   Link,
 } from "@nypl/design-system-react-components";
+import ButtonLink from "./../ButtonLink";
+import { ButtonLinkProps as ButtonLinkType } from "./../ButtonLink/ButtonLink";
 
 export interface CardProps {
   /** The id for the card. */
@@ -21,6 +24,8 @@ export interface CardProps {
   href: string;
   /** An optional image component that can be passed to the card. */
   image?: JSX.Element;
+  /** An optional set of button links. */
+  buttonLinks?: any;
   /** Optional value to render the layout in a row or column. */
   layout?: LayoutTypes;
   /** Optional value to control the alignment of the text and elements. */
@@ -36,6 +41,7 @@ export default function Card({
   description,
   href,
   image,
+  buttonLinks = null,
   layout,
   isCentered,
   isBordered = false,
@@ -63,7 +69,36 @@ export default function Card({
             dangerouslySetInnerHTML={{
               __html: description,
             }}
-          ></Box>
+          />
+        )}
+        {buttonLinks && (
+          <Flex
+            as="ul"
+            direction={{ sm: "column", md: "row" }}
+            gap="s"
+            {...(layout === "column" && {
+              justify: "center",
+              m: "auto",
+              w: { sm: "fit-content", md: "full" },
+            })}
+          >
+            {buttonLinks.map((buttonLink: ButtonLinkType) => (
+              <Box
+                id={`button-link-${buttonLink.id}`}
+                key={buttonLink.id}
+                as="li"
+                listStyleType="none"
+                w={{ sm: "full", md: "fit-content" }}
+                textAlign={{ sm: "center", lg: "initial" }}
+              >
+                <ButtonLink
+                  id={buttonLink.id}
+                  link={buttonLink.link}
+                  icon={buttonLink.icon}
+                />
+              </Box>
+            ))}
+          </Flex>
         )}
       </CardContent>
     </DsCard>

--- a/src/components/shared/CardGrid/CardGrid.tsx
+++ b/src/components/shared/CardGrid/CardGrid.tsx
@@ -40,6 +40,7 @@ export interface CardItem {
   description: string;
   image?: ImageType;
   link: string;
+  buttonLinks?: any;
 }
 
 export default function CardGrid({
@@ -126,7 +127,7 @@ export default function CardGrid({
       >
         {items &&
           items.map((item: CardItem, index) => {
-            const { id, title, description, link, image } = item;
+            const { id, title, description, link, image, buttonLinks } = item;
             return (
               <Box
                 as="li"
@@ -157,6 +158,7 @@ export default function CardGrid({
                       />
                     ),
                   })}
+                  buttonLinks={buttonLinks}
                 />
               </Box>
             );

--- a/src/components/shared/CardGrid/CardGrid.tsx
+++ b/src/components/shared/CardGrid/CardGrid.tsx
@@ -5,6 +5,7 @@ import Card from "./Card";
 import Image from "./../../shared/Image";
 import TextFormatted from "../TextFormatted";
 import { ImageType } from "../Image/ImageTypes";
+import { ButtonLinkProps as ButtonLinkType } from "./../ButtonLink/ButtonLink";
 
 export type CardGridLayoutTypes = "row" | "column" | "column_two_featured";
 
@@ -40,7 +41,7 @@ export interface CardItem {
   description: string;
   image?: ImageType;
   link: string;
-  buttonLinks?: any;
+  buttonLinks?: ButtonLinkType[];
 }
 
 export default function CardGrid({

--- a/src/components/shared/ContentComponents/ButtonLinks.tsx
+++ b/src/components/shared/ContentComponents/ButtonLinks.tsx
@@ -1,18 +1,7 @@
 import * as React from "react";
-import {
-  Box,
-  Flex,
-  Heading,
-  Link,
-  Icon,
-  IconNames,
-} from "@nypl/design-system-react-components";
-
-type ButtonLinkItem = {
-  id: string;
-  link: { title: string; url: string; uri: string };
-  icon: string;
-};
+import { Box, Flex, Heading } from "@nypl/design-system-react-components";
+import ButtonLink from "./../ButtonLink";
+import { ButtonLinkProps as ButtonLinkItem } from "./../ButtonLink/ButtonLink";
 
 interface ButtonLinksProps {
   id: string;
@@ -20,14 +9,6 @@ interface ButtonLinksProps {
   description?: string;
   items: ButtonLinkItem[];
 }
-
-// Lookup table to match drupal strings to the corresponding DS IconNames
-const IconTable: Record<string, IconNames> = {
-  facebook: "legacySocialFacebook",
-  instagram: "socialInstagram",
-  twitter: "socialTwitter",
-  file_type_doc: "fileTypeDoc",
-};
 
 export default function ButtonLinks({ id, heading, items }: ButtonLinksProps) {
   return (
@@ -58,39 +39,7 @@ export default function ButtonLinks({ id, heading, items }: ButtonLinksProps) {
                 listStyleType="none"
                 w={{ sm: "full", md: "fit-content" }}
               >
-                {/* @TODO once we are updating the DS version,
-                replace custome style with type="buttonSecondary"*/}
-                <Link
-                  id={`link-${id}`}
-                  href={item.link.url}
-                  type="action"
-                  w="full"
-                  py="xs"
-                  px="s"
-                  textDecor="none"
-                  color="ui.link.primary"
-                  bg="transparent"
-                  borderStyle="solid"
-                  borderWidth="1px"
-                  borderColor="ui.link.primary"
-                  _hover={{
-                    bg: "rgb(5, 118, 211,0.05 )",
-                    borderColor: "ui.link.secondary",
-                    color: "ui.link.secondary",
-                    textDecor: "none",
-                    svg: {
-                      color: "ui.link.secondary",
-                    },
-                  }}
-                >
-                  <Icon
-                    name={IconTable[item.icon]}
-                    size="small"
-                    align="left"
-                    color="ui.link.primary"
-                  />
-                  {item.link.title}
-                </Link>
+                <ButtonLink id={item.id} link={item.link} icon={item.icon} />
               </Box>
             ))}
         </Flex>


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-3546)
[Figma Design](https://www.figma.com/file/Yo3bXT18Lz7946ixcEtte9/RENO-Section-Fronts?type=design&node-id=4310-71278)

## **This PR does the following:**
- Adds button links to Card component.
- See https://github.com/NYPL/nypl-d8/pull/1061 for the D9 backend part of this work.

### Review Steps:

- [ ] Pull in branch `git fetch origin RENO-3546/card-grid-button-links`
- [ ] Switch to relevant brach `git checkout RENO-3546/card-grid-button-links`
- [ ] Start a local build `npm run build && npm start`
- [ ] Confirm tests are passing `npm test`

### Front End Review Steps:

- [ ] View [Example](http://localhost:3000/)
