### PR TITLE
RENO-3628: Add site_section value

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -5,10 +5,21 @@ const { NEXT_PUBLIC_GA_TRACKING_ID } = process.env;
 import "./../styles/main.scss";
 import AppLayout from "./../components/shared/layouts/AppLayout";
 import Error from "./_error";
+import submitAdobePageView from "../utils/submit-adobe-page-view";
 
 export default function ScoutApp({ Component, pageProps }: AppProps) {
   const router = useRouter();
-  // When next js routes change, send data to GA.
+
+  // Adobe Analytics: trigger an initial virtual page view.
+  useEffect(() => {
+    submitAdobePageView(
+      document.title,
+      window.location.pathname,
+      pageProps.bundle
+    );
+  }, []);
+
+  // When next js routes change, send data to GA/ AA.
   useEffect(() => {
     const handleRouteChange = (url: string) => {
       // Google Analytics: Virtual page view.
@@ -17,16 +28,11 @@ export default function ScoutApp({ Component, pageProps }: AppProps) {
       });
 
       // Adobe Analytics: Virtual page view.
-      window.adobeDataLayer.push({
-        page_name: null,
-        site_section: null,
-      });
-      const pageName = document.title.split("|")[0].trim();
-      window.adobeDataLayer.push({
-        event: "virtual_page_view",
-        page_name: pageName,
-        site_section: null,
-      });
+      submitAdobePageView(
+        document.title,
+        window.location.pathname,
+        pageProps.bundle
+      );
     };
     router.events.on("routeChangeComplete", handleRouteChange);
     return () => {

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -58,15 +58,10 @@ export default function Document() {
           strategy="afterInteractive"
           dangerouslySetInnerHTML={{
             __html: `
-              window.adobeDataLayer = [];
-              let pageName = document.title.split("|")[0].trim();
-              if (window.location.pathname === "/") {
-                pageName = "Home"
-              }
-              window.adobeDataLayer.push({
-                page_name: pageName,
-                site_section: null,
-              });
+            window.adobeDataLayer = window.adobeDataLayer || [];
+            window.adobeDataLayer.push({
+             disable_page_view: true
+            });
             `,
           }}
         />

--- a/src/utils/get-site-section.test.ts
+++ b/src/utils/get-site-section.test.ts
@@ -1,0 +1,31 @@
+import getSiteSection from "./get-site-section";
+
+describe("getSiteSection", () => {
+  it("should return the correct site section for single level slug.", () => {
+    expect(getSiteSection("/press")).toEqual("Press");
+  });
+
+  it("should return the correct site section for two level using starts with matching.", () => {
+    expect(getSiteSection("/press/press-release-1")).toEqual("Press");
+  });
+
+  it("should return the correct site section for multi level slug using starts with matching.", () => {
+    expect(
+      getSiteSection("/research/collections/articles-databases/search")
+    ).toEqual("Articles and Databases");
+  });
+
+  it("should return the correct site section for /", () => {
+    expect(getSiteSection("/")).toEqual("Home");
+  });
+
+  it("should return the correct site section when bundle is passed.", () => {
+    expect(getSiteSection("/research", "section_front")).toEqual(
+      "Section Front"
+    );
+  });
+
+  it("should return null if slug does not start with a /", () => {
+    expect(getSiteSection("research")).toBeNull();
+  });
+});

--- a/src/utils/get-site-section.ts
+++ b/src/utils/get-site-section.ts
@@ -1,0 +1,78 @@
+type MappingTableItem = {
+  input: `/${string}`;
+  siteSection: string;
+  method: "exactMatch" | "startsWith";
+};
+
+// An array of bundles that should use bundle method.
+const bundles = ["section_front"];
+
+// Lookup tables of bundle types and their site section names.
+const bundlesMap: Record<string, string> = {
+  section_front: "Section Front",
+};
+
+// Mapping table for exact match or starts with matches.
+const mappingTable: MappingTableItem[] = [
+  {
+    input: "/",
+    siteSection: "Home",
+    method: "exactMatch",
+  },
+  {
+    input: "/blog",
+    siteSection: "Blog",
+    method: "startsWith",
+  },
+  {
+    input: "/locations",
+    siteSection: "Locations",
+    method: "startsWith",
+  },
+  {
+    input: "/press",
+    siteSection: "Press",
+    method: "startsWith",
+  },
+  {
+    input: "/research/collections/articles-databases",
+    siteSection: "Articles and Databases",
+    method: "startsWith",
+  },
+];
+
+/**
+ * Gets the site section for a route, either by slug or bundle.
+ *
+ * @param {string} slug - The pathname of the route.
+ * @param {string} bundle - The Drupal bundle of the route.
+ *
+ * @return {string} siteSection - The site section for the route.
+ */
+export default function getSiteSection(
+  slug: string,
+  bundle?: string
+): string | null {
+  // If slug doesn't start with a /, return null.
+  if (!slug.startsWith("/")) {
+    return null;
+  }
+
+  // If bundle parameter is provided, we use that instead of the slug for resolving site section.
+  if (bundle && bundles.includes(bundle)) {
+    return bundlesMap[bundle];
+  }
+
+  // Resolve the site section via the mapping table configuration.
+  return mappingTable.reduce((siteSection: string, item: MappingTableItem) => {
+    if (item.method === "exactMatch" && item.input === slug) {
+      siteSection = item.siteSection;
+    }
+
+    if (item.method === "startsWith" && slug.startsWith(item.input)) {
+      siteSection = item.siteSection;
+    }
+
+    return siteSection;
+  }, "");
+}

--- a/src/utils/submit-adobe-page-view.ts
+++ b/src/utils/submit-adobe-page-view.ts
@@ -1,0 +1,23 @@
+import getSiteSection from "./get-site-section";
+
+export default function submitAdobePageView(
+  title: string,
+  pathname: string,
+  bundle: string
+) {
+  window.adobeDataLayer.push({
+    page_name: null,
+    site_section: null,
+  });
+
+  const pageName =
+    title === "The New York Public Library" ? "Home" : title.split("|")[0];
+
+  const siteSection = getSiteSection(pathname, bundle);
+
+  window.adobeDataLayer.push({
+    event: "virtual_page_view",
+    page_name: pageName,
+    site_section: siteSection,
+  });
+}


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-3628)

## **This PR does the following:**

- Adds `getSiteSection` function to map Site Section values
- Adds test for `getSiteSection` function
- Adds `submitAdobePageView` function to handle the logic for `virtual_page-view` events
- Updates _document to omit initial page view upon page load
- Update _app to send `virtual_page_view` events on initial age load and all rout changes

### Review Steps:

- [ ] Pull in branch `git fetch origin RENO-3628/get-site-section`
- [ ] Switch to relevant brach `git checkout RENO-3628/get-site-section`
- [ ] Start a local build `npm run build && npm start`
- [ ] Confirm tests are passing `npm test`

### Front End Review Steps:

- [ ] View [Homepage](http://localhost:3000/)
- [ ] Confirm that the AA event object sends the correct site_section value upon page load
- [ ] View [Blog page](http://localhost:3000/blog)
- [ ] Navigate to Channels page
- [ ] Confirm that the AA object the correct site_section value upon route change
