### PR TITLE
RENO-3625: AA Update Page Name

### DIFF
--- a/src/components/shared/FilterBar/FilterBar.tsx
+++ b/src/components/shared/FilterBar/FilterBar.tsx
@@ -78,7 +78,7 @@ function FilterBar({
       }
     }
     setSelectedItems(urlState);
-  }, [router.query]);
+  }, [router]);
 
   //
   function onMenuClick(groupId: string) {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -12,11 +12,7 @@ export default function ScoutApp({ Component, pageProps }: AppProps) {
 
   // Adobe Analytics: trigger an initial virtual page view.
   useEffect(() => {
-    submitAdobePageView(
-      document.title,
-      window.location.pathname,
-      pageProps.bundle
-    );
+    submitAdobePageView(router.asPath, pageProps.bundle);
   }, []);
 
   // When next js routes change, send data to GA/ AA.
@@ -28,17 +24,13 @@ export default function ScoutApp({ Component, pageProps }: AppProps) {
       });
 
       // Adobe Analytics: Virtual page view.
-      submitAdobePageView(
-        document.title,
-        window.location.pathname,
-        pageProps.bundle
-      );
+      submitAdobePageView(router.asPath, pageProps.bundle);
     };
     router.events.on("routeChangeComplete", handleRouteChange);
     return () => {
       router.events.off("routeChangeComplete", handleRouteChange);
     };
-  }, [router.events]);
+  }, [router]);
 
   // Handle errors.
   if (pageProps.errorCode) {

--- a/src/utils/get-site-section.ts
+++ b/src/utils/get-site-section.ts
@@ -20,6 +20,11 @@ const mappingTable: MappingTableItem[] = [
     method: "exactMatch",
   },
   {
+    input: "/home",
+    siteSection: "Home",
+    method: "exactMatch",
+  },
+  {
     input: "/blog",
     siteSection: "Blog",
     method: "startsWith",

--- a/src/utils/submit-adobe-page-view.ts
+++ b/src/utils/submit-adobe-page-view.ts
@@ -1,19 +1,16 @@
 import getSiteSection from "./get-site-section";
 
-export default function submitAdobePageView(
-  title: string,
-  pathname: string,
-  bundle: string
-) {
+export default function submitAdobePageView(path: string, bundle: string) {
+  // Remove query parameters from path
+  const slug = path.replace(/\?.+/, "");
   window.adobeDataLayer.push({
     page_name: null,
     site_section: null,
   });
 
-  const pageName =
-    title === "The New York Public Library" ? "Home" : title.split("|")[0];
+  const pageName = path.replace(/^\//g, "nypl|").replace(/\//g, "|");
 
-  const siteSection = getSiteSection(pathname, bundle);
+  const siteSection = getSiteSection(slug, bundle);
 
   window.adobeDataLayer.push({
     event: "virtual_page_view",


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-3625)

## **This PR does the following:**

- Updates props for submit-adobe-page-view 
- Adds logic for new page_name values
- Updates the dependency array in FilterBar.tsx to fix lag in query params on router

### Review Steps:

- [ ] Pull in branch `git fetch origin RENO-3625/update-page-name`
- [ ] Switch to relevant brach `git checkout RENO-3625/update-page-name`
- [ ] Start a local build `npm run build && npm start`
- [ ] Confirm tests are passing `npm test`
- [ ] Use the [Page Name list for nypl.org](https://blastwiki.atlassian.net/wiki/spaces/NYPL/pages/7898713056097665227/Page+Name+Taxonomy+-+URLs+and+EXAMPLE+PAGE+NAMES) and compare to [Adobe Dashboard](https://experience.adobe.com/#/@nypl/so:newyorc/analytics/spa/index.html?switch_from_accnt=nyplentitiesprod&jpj=12565078812123&ssSession=b562f404aa0a206a07cae56eb07942cc#/real-time?reportSuiteChanged=1) to confirm page name values

### Front End Review Steps:

- [ ] View [Example](http://localhost:3000/)
