### PR TITLE
RENO-3773: Setup Breadcrumbs for Pages

### DIFF
--- a/src/apollo/server/resolvers/drupal-types.ts
+++ b/src/apollo/server/resolvers/drupal-types.ts
@@ -18,6 +18,12 @@ export interface DrupalJsonApiTextField {
   processed: string;
 }
 
+export interface DrupalJsonApiBreadcrumbItem {
+  id: string;
+  title: string;
+  url: string;
+}
+
 export interface DrupalJsonApiMediaImageResource {
   type:
     | "media--image"

--- a/src/apollo/server/resolvers/page-resolver.ts
+++ b/src/apollo/server/resolvers/page-resolver.ts
@@ -1,5 +1,6 @@
 import { getIndividualResourceJsonApiPath } from "./../datasources/drupal-json-api/getJsonApiPath";
 import {
+  DrupalJsonApiBreadcrumbItem,
   DrupalJsonApiEntityResource,
   DrupalJsonApiTextField,
   DrupalJsonApiMediaImageResource,
@@ -11,6 +12,7 @@ import { getDrupalParagraphsField } from "./drupal-paragraphs/get-drupal-paragra
 export interface PageJsonApiResource {
   id: string;
   title: string;
+  breadcrumbs: DrupalJsonApiBreadcrumbItem[];
   field_tfls_summary_description: DrupalJsonApiTextField;
   field_ers_media_image: DrupalJsonApiMediaImageResource;
   field_lts_hero_type: string;
@@ -91,6 +93,7 @@ export const pageResolver = {
     title: (page: PageJsonApiResource) => page.title,
     description: (page: PageJsonApiResource) =>
       page.field_tfls_summary_description.processed,
+    breadcrumbs: (page: PageJsonApiResource) => page.breadcrumbs,
     image: (page: PageJsonApiResource) =>
       page.field_ers_media_image.data !== null
         ? resolveImage(page.field_ers_media_image)

--- a/src/apollo/server/type-defs/page.ts
+++ b/src/apollo/server/type-defs/page.ts
@@ -4,6 +4,7 @@ export const PageTypeDefs = gql`
   type Page {
     id: ID!
     title: String!
+    breadcrumbs: [BreadcrumbsItem]
     description: String
     image: Image
     # breadcrumbs: [BreadcrumbsItem]

--- a/src/components/pages/Page.tsx
+++ b/src/components/pages/Page.tsx
@@ -2,7 +2,9 @@ import * as React from "react";
 // Apollo
 import { gql, useQuery } from "@apollo/client";
 // Components
-import PageContainer from "../shared/layouts/PageContainer";
+import PageContainer, {
+  BreadcrumbsItem,
+} from "../shared/layouts/PageContainer";
 import PreviewModeNotification from "../shared/PreviewModeNotification";
 import Hero from "./../shared/Hero";
 import CardGrid from "./../shared/CardGrid";
@@ -25,6 +27,11 @@ export const PAGE_QUERY = gql`
     page(id: $id, revisionId: $revisionId, preview: $preview) {
       id
       title
+      breadcrumbs {
+        id
+        title
+        url
+      }
       description
       image {
         id
@@ -280,27 +287,21 @@ export default function PagePage({
         description: page.description,
         imageUrl: page.image?.uri,
       }}
-      breadcrumbs={[
-        {
-          text: "Hello",
-          url: "/whatever",
-        },
-      ]}
-      // breadcrumbs={
-      //   sectionFront.breadcrumbs &&
-      //   sectionFront.breadcrumbs.map(
-      //     (breadcrumbsItem: {
-      //       id: string;
-      //       title: string;
-      //       url: string;
-      //     }): BreadcrumbsItem => {
-      //       return {
-      //         text: breadcrumbsItem.title,
-      //         url: breadcrumbsItem.url,
-      //       };
-      //     }
-      //   )
-      // }
+      breadcrumbs={
+        page.breadcrumbs &&
+        page.breadcrumbs.map(
+          (breadcrumbsItem: {
+            id: string;
+            title: string;
+            url: string;
+          }): BreadcrumbsItem => {
+            return {
+              text: breadcrumbsItem.title,
+              url: breadcrumbsItem.url,
+            };
+          }
+        )
+      }
       // breadcrumbsColor={sectionFront.colorway.secondary}
       wrapperClass="nypl--page"
       contentHeader={

--- a/src/components/shared/DonorCredit/__snapshots__/DonorCredit.test.tsx.snap
+++ b/src/components/shared/DonorCredit/__snapshots__/DonorCredit.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`DonorCredit tests should render the UI snapshot correctly 1`] = `
     className="css-144igvy"
   >
     <div
-      className="css-15ok9kq"
+      className="css-y1avno"
       dangerouslySetInnerHTML={
         {
           "__html": "Test Description",
@@ -42,7 +42,7 @@ exports[`DonorCredit tests should render the UI snapshot correctly 2`] = `
     className="css-144igvy"
   >
     <div
-      className="css-15ok9kq"
+      className="css-y1avno"
       dangerouslySetInnerHTML={
         {
           "__html": "Test Description",
@@ -62,7 +62,7 @@ exports[`DonorCredit tests should render the UI snapshot correctly 3`] = `
     className="css-144igvy"
   >
     <div
-      className="css-15ok9kq"
+      className="css-y1avno"
       dangerouslySetInnerHTML={
         {
           "__html": "Test Description",


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-3773)

## **This PR does the following:**

- Updates page schema with breadcrumbs
- Updates page resolver with breadcrumbs
- Adds `DrupalJsonApiBreadcrumbItem` type to `drupal-types.ts`
- Adds breadcrumbs to `PAGE_QUERY`
- Updates Page component with breadcrumbs

### Review Steps:

- [ ] Pull in branch `git fetch origin RENO-3773/connect-breadcrumbs-for-basic-pages`
- [ ] Switch to relevant brach `git checkout RENO-3773/connect-breadcrumbs-for-basic-pages`
- [ ] Start a local build `npm run build && npm start`
- [ ] Confirm tests are passing `npm test`

### Front End Review Steps:

- [ ] Spin up local drupal instance
- [ ] Create a Page entity in Drupal/ Confirm a page entity is setup locally
- [ ] Navigate on [Localhost](http://localhost:3000/) to your Basic Page
