### PR TITLE
RENO-3786: Extend TextWithImage Component

### DIFF
--- a/src/apollo/client/fragments/blogFields.js
+++ b/src/apollo/client/fragments/blogFields.js
@@ -50,6 +50,7 @@ export const BLOG_FIELDS_FRAGMENT = gql`
             uri
           }
         }
+        imageAlignment
       }
       ... on Text {
         id

--- a/src/apollo/client/fragments/pressFields.js
+++ b/src/apollo/client/fragments/pressFields.js
@@ -45,6 +45,7 @@ export const PRESS_FIELDS_FRAGMENT = gql`
             uri
           }
         }
+        imageAlignment
       }
       ... on ImageComponent {
         id

--- a/src/apollo/server/resolvers/drupal-paragraphs/text-with-image-resolver.ts
+++ b/src/apollo/server/resolvers/drupal-paragraphs/text-with-image-resolver.ts
@@ -9,6 +9,7 @@ type DrupalJsonApiTextWithImageParagraph = {
   field_ts_heading: string;
   field_tfls_summary_descrip: DrupalJsonApiTextField;
   field_ers_media_item: DrupalJsonApiMediaImageResource;
+  field_lts_image_alignment: "left" | "right";
 };
 
 export const TextWithImageResolver = {
@@ -31,5 +32,9 @@ export const TextWithImageResolver = {
       parent.field_ers_media_item.data === null
         ? null
         : resolveImage(parent.field_ers_media_item),
+    imageAlignment: (parent: DrupalJsonApiTextWithImageParagraph) =>
+      parent.field_lts_image_alignment === null
+        ? "left"
+        : parent.field_lts_image_alignment,
   },
 };

--- a/src/apollo/server/type-defs/page.ts
+++ b/src/apollo/server/type-defs/page.ts
@@ -7,7 +7,6 @@ export const PageTypeDefs = gql`
     breadcrumbs: [BreadcrumbsItem]
     description: String
     image: Image
-    # breadcrumbs: [BreadcrumbsItem]
     featuredContent: PageFeaturedContent
     mainContent: [PageMainContent]
   }

--- a/src/apollo/server/type-defs/shared.js
+++ b/src/apollo/server/type-defs/shared.js
@@ -82,6 +82,7 @@ export const typeDefs = gql`
     image: Image
     caption: String
     credit: String
+    imageAlignment: String
   }
 
   type Video {

--- a/src/components/blogs/BlogPost/BlogPost.tsx
+++ b/src/components/blogs/BlogPost/BlogPost.tsx
@@ -7,6 +7,7 @@ import GoogleMapEmbed from "../../shared/ContentComponents/GoogleMapEmbed";
 import ImageComponent from "../../shared/ContentComponents/ImageComponent";
 import SocialEmbed from "../../shared/ContentComponents/SocialEmbed";
 import Text from "../../shared/ContentComponents/Text";
+import TextWithImage from "../../shared/ContentComponents/TextWithImage";
 import Video from "../../shared/ContentComponents/Video";
 
 import {
@@ -21,8 +22,6 @@ interface BlogPostProps {
 }
 
 export default function BlogPost({ blog }: BlogPostProps) {
-  console.log(blog);
-
   return (
     <Box as="article" w="100%" maxW="866px">
       <Box as="header" pb={10}>
@@ -52,6 +51,7 @@ export default function BlogPost({ blog }: BlogPostProps) {
           ImageComponent: ImageComponent,
           SocialEmbed: SocialEmbed,
           Text: Text,
+          TextWithImage: TextWithImage,
           Video: Video,
         }}
       />

--- a/src/components/pages/Page.tsx
+++ b/src/components/pages/Page.tsx
@@ -213,6 +213,7 @@ export const PAGE_QUERY = gql`
               uri
             }
           }
+          imageAlignment
         }
         ... on Video {
           id

--- a/src/components/shared/ContentComponents/TextWithImage.tsx
+++ b/src/components/shared/ContentComponents/TextWithImage.tsx
@@ -12,6 +12,7 @@ interface TextWithImageProps {
   caption?: string;
   credit?: string;
   image?: any;
+  imageAlignment: "left" | "right";
 }
 
 function TextWithImage({
@@ -22,6 +23,7 @@ function TextWithImage({
   caption,
   credit,
   image,
+  imageAlignment = "left",
 }: TextWithImageProps) {
   let imageSrc: string = image?.uri;
   if (image?.transformations) {
@@ -41,8 +43,10 @@ function TextWithImage({
         <Box
           width="100%"
           maxWidth={{ base: "auto", md: "25%", lg: "40%" }}
-          float={{ md: "left" }}
-          mr={{ md: "l" }}
+          float={{ md: `${imageAlignment}` }}
+          {...(imageAlignment === "right"
+            ? { ml: { ...{ md: "l" } } }
+            : { mr: { ...{ md: "l" } } })}
           mb="s"
         >
           <Image


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-3786)

## **This PR does the following:**

- Adds `imageAlignment` to TextWithImage schema and resolver
- Adds `imageAlignment` to TextWithImage Component
- Adds `imageAlignment` to Page, Blog and Press query
- Adds TextWithImage to BlogPost.tsx

### Review Steps:

- [ ] Pull in branch `git fetch origin RENO-3786/extend-textWithImage-component`
- [ ] Switch to relevant brach `git checkout RENO-3786/extend-textWithImage-component`
- [ ] Start a local build `npm run build && npm start`
- [ ] Confirm unit tests are passing `npm test`
- [ ] Confirm cypress tests are passing `npm run build && npm start` and `npm run cypress` in separate terminals

### Front End Review Steps:

- [ ] View [Old BlogPost with TextWithImage](http://localhost:3000//blog/2023/07/20/berenice-abbott-papers-pioneering-photographer)
- [ ] View a local BasicPage
