### PR TITLE
RENO-3735: Add image source link to TextWithImage

### DIFF
--- a/src/apollo/client/fragments/blogFields.js
+++ b/src/apollo/client/fragments/blogFields.js
@@ -38,6 +38,7 @@ export const BLOG_FIELDS_FRAGMENT = gql`
         text
         caption
         credit
+        link
         image {
           id
           alt

--- a/src/apollo/client/fragments/pressFields.js
+++ b/src/apollo/client/fragments/pressFields.js
@@ -33,6 +33,7 @@ export const PRESS_FIELDS_FRAGMENT = gql`
         text
         caption
         credit
+        link
         image {
           id
           alt

--- a/src/apollo/server/resolvers/utils/resolveDrupalParagraphs.ts
+++ b/src/apollo/server/resolvers/utils/resolveDrupalParagraphs.ts
@@ -190,6 +190,22 @@ export default function resolveDrupalParagraphs(
     switch (item.type) {
       case "paragraph--text_with_image":
         const textWithImageMedia: any = item.field_ers_media_item;
+        let mediaItemLink = null;
+        // Media DC image.
+        if (
+          textWithImageMedia.type === "media--digital_collections_image" &&
+          textWithImageMedia.field_media_dc_link !== null
+        ) {
+          mediaItemLink = textWithImageMedia.field_media_dc_link.url;
+        }
+        // Media image & remote catalog image.
+        if (
+          textWithImageMedia.type === "media--image" ||
+          textWithImageMedia.type === "media--remote_catalog_image"
+        ) {
+          mediaItemLink =
+            textWithImageMedia.field_media_image_link_url_only?.url;
+        }
         paragraphComponent = {
           id: item.id,
           type: paragraphTypeName,
@@ -201,6 +217,7 @@ export default function resolveDrupalParagraphs(
           credit: textWithImageMedia.field_media_image_credit_html
             ? textWithImageMedia.field_media_image_credit_html.processed
             : null,
+          link: mediaItemLink,
           image:
             item.field_ers_media_item.data === null
               ? null

--- a/src/apollo/server/type-defs/shared.js
+++ b/src/apollo/server/type-defs/shared.js
@@ -80,6 +80,7 @@ export const typeDefs = gql`
     heading: String
     text: String!
     image: Image
+    link: String
     caption: String
     credit: String
   }

--- a/src/components/shared/ContentComponents/ImageComponent.tsx
+++ b/src/components/shared/ContentComponents/ImageComponent.tsx
@@ -17,7 +17,7 @@ interface WithLinkProps {
 }
 
 // Wrapper function to add a Link parent component.
-function WithLink({ link, children }: WithLinkProps) {
+export function WithLink({ link, children }: WithLinkProps) {
   if (link) {
     return <a href={link}>{children}</a>;
   }

--- a/src/components/shared/ContentComponents/TextWithImage.tsx
+++ b/src/components/shared/ContentComponents/TextWithImage.tsx
@@ -3,6 +3,7 @@ import { Box, Heading } from "@nypl/design-system-react-components";
 import TextFormatted from "./../TextFormatted";
 import Image from "next/image";
 import { getImageTransformation } from "./../../shared/Image/imageUtils";
+import { WithLink } from "./ImageComponent";
 
 interface TextWithImageProps {
   id: string;
@@ -11,6 +12,7 @@ interface TextWithImageProps {
   text: string;
   caption?: string;
   credit?: string;
+  link?: string;
   image?: any;
 }
 
@@ -21,6 +23,7 @@ function TextWithImage({
   text,
   caption,
   credit,
+  link,
   image,
 }: TextWithImageProps) {
   let imageSrc: string = image?.uri;
@@ -45,14 +48,16 @@ function TextWithImage({
           mr={{ md: "l" }}
           mb="s"
         >
-          <Image
-            id={image.id}
-            alt={image.alt}
-            src={imageSrc}
-            layout="responsive"
-            width={image.width}
-            height={image.height}
-          />
+          <WithLink link={link}>
+            <Image
+              id={image.id}
+              alt={image.alt}
+              src={imageSrc}
+              layout="responsive"
+              width={image.width}
+              height={image.height}
+            />
+          </WithLink>
           {caption && (
             <Box fontSize="-1" fontWeight="regular">
               {caption}


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-3735)

## **This PR does the following:**

- Adds link data to `TextWithImage` schema, resolver and query
- Adds link prop to `TextWithImage` component
- Exports `WithLink` component from `ImageComponent` to be used in `TextWithImage` component

### Review Steps:

- [ ] Pull in branch `git fetch origin RENO-3735/enable-dc-image-link-in-text-with-image`
- [ ] Switch to relevant brach `git checkout RENO-3735/enable-dc-image-link-in-text-with-image`
- [ ] Start a local build `npm run build && npm start`
- [ ] Confirm unit tests are passing `npm test`
- [ ] Confirm cypress tests are passing `npm run build && npm start` and `npm run cypress` in separate terminals

### Front End Review Steps:

- [ ] Visit [Live Blog Post](https://www.nypl.org/blog/2023/07/20/berenice-abbott-papers-pioneering-photographer)
- [ ] Confirm no image is linking out to the image source page.
- [ ] View [The Blog Post PR Preview](https://scout-git-reno-3735-enable-dc-image-link-in-text-wi-821eab-nypl.vercel.app/blog/2023/07/20/berenice-abbott-papers-pioneering-photographer)
- [ ] Confirm that the second image is linking out to the image source page.
- [ ] Look at the [Drupal JSON data](https://drupal.nypl.org/jsonapi/node/blog/01fdc2df-a7ca-4fa3-9f1d-35c12e8fab9e?include=field_ers_media_image.field_media_image,field_main_content.field_ers_media_item.field_media_image,field_erm_location,field_main_content.field_erm_link_cards,field_main_content.field_erm_link_cards.field_ers_image.field_media_image&jsonapi_include=1)
- [ ] Confirm that the second item in `field_main_content` is or type `paragraph--text_with_image` and the `field_ers_media_item.field_media_dc_link` is populated.
- [ ] Confirm that the value of the other `paragraph--text_with_image` in `field_main_content` have the `field_ers_media_item.field_media_image_link_url_only` or `field_ers_media_item.field_media_dc_link` set to `null`