### PR TITLE
RENO-3796: Allow contentcafe12.btol.com as Image Source

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -64,6 +64,7 @@ const nextConfig = {
       "imagesb.btol.com",
       "contentcafecloud.baker-taylor.com",
       "contentcafe11.btol.com",
+      "contentcafe12.btol.com",
       "img1.od-cdn.com",
       "ic.od-cdn.com",
     ],


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-3796)

## **This PR does the following:**

- Add contentcafe12.btol.com to next.config.js image source whitelist.

### Review Steps:

- [ ] Clone this branch locally
- [ ] Start a local build `npm run build && npm start`
- [ ] Confirm unit tests are passing `npm test`
- [ ] Confirm cypress tests are passing `npm run build && npm start` and `npm run cypress` in separate terminals

