### PR TITLE
RENO-3735: Update TextWithImage with image source link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@apollo/client": "3.6.9",
         "@chakra-ui/react": "1.8.8",
-        "@nypl/design-system-react-components": "2.0.1",
+        "@nypl/design-system-react-components": "2.1.2",
         "@nypl/dgx-react-footer": "^0.5.8",
         "@react-google-maps/api": "^2.12.0",
         "@reduxjs/toolkit": "^1.9.3",
@@ -3255,12 +3255,12 @@
       }
     },
     "node_modules/@nypl/design-system-react-components": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@nypl/design-system-react-components/-/design-system-react-components-2.0.1.tgz",
-      "integrity": "sha512-gMfCmlP3iTAhxRxBpbX0iWK5r++qwkUdh/8fM1Ae4npdnN7MDNNDrG+3LHgdwzZpxOjXOZrLLTPlAjssOiGQkA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@nypl/design-system-react-components/-/design-system-react-components-2.1.2.tgz",
+      "integrity": "sha512-i+jkEE784Rwbvayd1tpB8iu1puo4Al+Ttgn1wOKlOeoNudiW7QD9hzONL4/rb+VyS3tcZIeYzOdclUi6gnSS1A==",
       "dependencies": {
         "@chakra-ui/focus-lock": ">=1.2.6 <2.0.0",
-        "@chakra-ui/react": ">=1.8.5 <=1.8.8",
+        "@chakra-ui/react": ">=1.8.5 <=1.8.9",
         "@chakra-ui/system": ">=1.11.0 <=1.12.1",
         "@charlietango/use-native-lazy-loading": "1.10.0",
         "@emotion/react": "11.4.1",
@@ -3279,7 +3279,7 @@
       },
       "peerDependencies": {
         "@chakra-ui/focus-lock": ">=1.2.6 <2.0.0",
-        "@chakra-ui/react": ">=1.8.5 <=1.8.8",
+        "@chakra-ui/react": ">=1.8.5 <=1.8.9",
         "@chakra-ui/system": ">=1.11.0 <=1.12.1",
         "@emotion/react": "11.4.1",
         "@emotion/styled": "11.3.0",
@@ -16773,12 +16773,12 @@
       }
     },
     "@nypl/design-system-react-components": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@nypl/design-system-react-components/-/design-system-react-components-2.0.1.tgz",
-      "integrity": "sha512-gMfCmlP3iTAhxRxBpbX0iWK5r++qwkUdh/8fM1Ae4npdnN7MDNNDrG+3LHgdwzZpxOjXOZrLLTPlAjssOiGQkA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@nypl/design-system-react-components/-/design-system-react-components-2.1.2.tgz",
+      "integrity": "sha512-i+jkEE784Rwbvayd1tpB8iu1puo4Al+Ttgn1wOKlOeoNudiW7QD9hzONL4/rb+VyS3tcZIeYzOdclUi6gnSS1A==",
       "requires": {
         "@chakra-ui/focus-lock": ">=1.2.6 <2.0.0",
-        "@chakra-ui/react": ">=1.8.5 <=1.8.8",
+        "@chakra-ui/react": ">=1.8.5 <=1.8.9",
         "@chakra-ui/system": ">=1.11.0 <=1.12.1",
         "@charlietango/use-native-lazy-loading": "1.10.0",
         "@emotion/react": "11.4.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@apollo/client": "3.6.9",
     "@chakra-ui/react": "1.8.8",
-    "@nypl/design-system-react-components": "2.0.1",
+    "@nypl/design-system-react-components": "2.1.2",
     "@nypl/dgx-react-footer": "^0.5.8",
     "@react-google-maps/api": "^2.12.0",
     "@reduxjs/toolkit": "^1.9.3",

--- a/src/apollo/server/resolvers/drupal-paragraphs/image-resolver.ts
+++ b/src/apollo/server/resolvers/drupal-paragraphs/image-resolver.ts
@@ -6,7 +6,7 @@ type DrupalJsonApiImageParagraph = {
   field_ers_media_item: DrupalJsonApiMediaImageResource;
 };
 
-function getImageLink(mediaResource: DrupalJsonApiMediaImageResource) {
+export function getImageLink(mediaResource: DrupalJsonApiMediaImageResource) {
   let imageLink = null;
   // Media DC image.
   if (

--- a/src/apollo/server/resolvers/drupal-paragraphs/text-with-image-resolver.ts
+++ b/src/apollo/server/resolvers/drupal-paragraphs/text-with-image-resolver.ts
@@ -3,6 +3,7 @@ import {
   DrupalJsonApiTextField,
   DrupalJsonApiMediaImageResource,
 } from "./../drupal-types";
+import { getImageLink } from "./image-resolver";
 
 type DrupalJsonApiTextWithImageParagraph = {
   id: string;
@@ -28,6 +29,8 @@ export const TextWithImageResolver = {
       parent.field_ers_media_item.field_media_image_credit_html
         ? parent.field_ers_media_item.field_media_image_credit_html.processed
         : null,
+    link: (parent: DrupalJsonApiTextWithImageParagraph) =>
+      getImageLink(parent.field_ers_media_item),
     image: (parent: DrupalJsonApiTextWithImageParagraph) =>
       parent.field_ers_media_item.data === null
         ? null

--- a/src/apollo/server/type-defs/shared.js
+++ b/src/apollo/server/type-defs/shared.js
@@ -83,7 +83,6 @@ export const typeDefs = gql`
     link: String
     caption: String
     credit: String
-    link: String
     imageAlignment: String
   }
 

--- a/src/apollo/server/type-defs/shared.js
+++ b/src/apollo/server/type-defs/shared.js
@@ -82,6 +82,7 @@ export const typeDefs = gql`
     image: Image
     caption: String
     credit: String
+    link: String
     imageAlignment: String
   }
 

--- a/src/components/pages/Page.tsx
+++ b/src/components/pages/Page.tsx
@@ -201,6 +201,7 @@ export const PAGE_QUERY = gql`
           text
           caption
           credit
+          link
           image {
             id
             alt


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-3735)

## **This PR does the following:**

- Adds link to new `TextWithImage` resolver
- Adds link to `TextWithImage` schema to avoid error
- Adds `link` to Page component query
- Upgrades `nypl/design-system-react-components` to version 2.1.2 - this fixes the Hero bg 

### Review Steps:

- [ ] Pull in branch `git fetch origin RENO-3735/update-text-with-image-with-image-link`
- [ ] Switch to relevant brach `git checkout RENO-3735/update-text-with-image-with-image-link`
- [ ] Start a local build `npm run build && npm start`
- [ ] Confirm unit tests are passing `npm test`
- [ ] Confirm cypress tests are passing `npm run build && npm start` and `npm run cypress` in separate terminals
- [ ] If not connecting to a Drupal Multidev that has the current Basic-Pages changes, the TextWithImage will be broken (Image will render above text). To fix this temporarily, add 
```
if (imageAlignment === null) {
    imageAlignment = "left";
  }
``` 
to the TextWithImage component.

### Front End Review Steps:
 _There changes will only show the following if [PR 465](https://github.com/NYPL/dxp-react-search/pull/465) was previously merged to development and this basic-pages-epic and this branch were updated with those changes_
- [ ] View [Blog Post on Localhost](http://localhost:3000/blog/2023/07/20/berenice-abbott-papers-pioneering-photographer)
- [ ] Confirm the second Image is linked to the source page in Digital Collections
