### PR TITLE
RENO-3918: Add enableSidebar to Page

### DIFF
--- a/src/apollo/server/resolvers/page.ts
+++ b/src/apollo/server/resolvers/page.ts
@@ -13,6 +13,7 @@ export interface PageJsonApiResource {
   id: string;
   title: string;
   breadcrumbs: DrupalJsonApiBreadcrumbItem[];
+  field_bs_enable_sidebar: boolean;
   field_tfls_summary_description: DrupalJsonApiTextField;
   field_ers_media_image: DrupalJsonApiMediaImageResource;
   field_lts_hero_type: string;
@@ -92,6 +93,7 @@ export const pageResolver = {
     description: (page: PageJsonApiResource) =>
       page.field_tfls_summary_description.processed,
     breadcrumbs: (page: PageJsonApiResource) => page.breadcrumbs,
+    enableSidebar: (page: PageJsonApiResource) => page.field_bs_enable_sidebar,
     image: (page: PageJsonApiResource) =>
       page.field_ers_media_image.data !== null
         ? resolveImage(page.field_ers_media_image)

--- a/src/apollo/server/type-defs/page.ts
+++ b/src/apollo/server/type-defs/page.ts
@@ -5,6 +5,7 @@ export const pageTypeDefs = gql`
     id: ID!
     title: String!
     breadcrumbs: [BreadcrumbsItem]
+    enableSidebar: Boolean
     description: String
     image: Image
     featuredContent: PageFeaturedContent

--- a/src/components/pages/Page.tsx
+++ b/src/components/pages/Page.tsx
@@ -32,6 +32,7 @@ export const PAGE_QUERY = gql`
         title
         url
       }
+      enableSidebar
       description
       image {
         id
@@ -266,6 +267,7 @@ export default function PagePage({
   const page = data.page;
 
   const showHero = page.featuredContent === null ? false : true;
+  const showSidebar = page.enableSidebar;
 
   return (
     <PageContainer
@@ -303,6 +305,16 @@ export default function PagePage({
           )}
         </>
       }
+      showSidebar={showSidebar}
+      sidebarSide="left"
+      {...(showSidebar && {
+        contentSecondary: (
+          <>
+            <h4>Placeholder</h4>
+            <p>Sidebar Left</p>
+          </>
+        ),
+      })}
       contentPrimary={
         <DrupalParagraphs
           content={page.mainContent}

--- a/src/components/shared/layouts/PageContainer.module.css
+++ b/src/components/shared/layouts/PageContainer.module.css
@@ -48,6 +48,30 @@
   }
 }
 
+.gridWithLeftSidebar {
+  max-width: 1280px;
+  width: 100%;
+  margin: 0 auto;
+  padding: var(--nypl-space-xl) var(--nypl-space-s);
+
+  display: grid;
+  grid-gap: 2rem;
+  grid-template-areas:
+    "contentSecondary"
+    "contentPrimary"
+    "contentBottom";
+}
+
+@media (min-width: 600px) {
+  .gridWithLeftSidebar {
+    padding: var(--nypl-space-xl) var(--nypl-space-s);
+    grid-template-columns: 250px auto;
+    grid-template-areas:
+      "contentSecondary contentPrimary"
+      "contentBottom  contentBottom";
+  }
+}
+
 .contentPrimary {
   grid-area: contentPrimary;
 }

--- a/src/components/shared/layouts/PageContainer.tsx
+++ b/src/components/shared/layouts/PageContainer.tsx
@@ -78,7 +78,7 @@ function PageContainer({
                   {contentPrimary}
                 </div>
               )}
-              {contentSecondary && showSidebar && sidebarSide === "right" && (
+              {contentSecondary && showSidebar && (
                 <div
                   id="page-container--content-secondary"
                   className={s.contentSecondary}


### PR DESCRIPTION
[Jira Ticket](https://jira.nypl.org/browse/RENO-3918)
[Figma Design](https://www.figma.com/file/XXX)

## **This PR does the following:**

- Adds enableSidebar type to Page type
- Adds enableSidebar to page resolver
- Adds enableSidebar to page query
- Updates PageContainer and pageContainer styles to render a left sidebar

### Review Steps:

- [ ] Pull in branch `git fetch origin RENO-3918/wire-up-enable-sidebar`
- [ ] Switch to relevant brach `git checkout RENO-3918/wire-up-enable-sidebar`
- [ ] Start a local build `npm run build && npm start`
- [ ] Confirm unit tests are passing `npm test`
- [ ] Confirm cypress tests are passing `npm run build && npm start` and `npm run cypress` in separate terminals

### Front End Review Steps:

- [ ] View [Example](http://localhost:3000/about)
